### PR TITLE
increase write timeout for guard

### DIFF
--- a/docs/reference/guard_run.md
+++ b/docs/reference/guard_run.md
@@ -65,6 +65,7 @@ guard run [flags]
       --ldap.user-search-filter string             Filter to apply when searching user (default "(objectClass=person)")
       --max-clock-skew duration                    Max acceptable clock skew for server clock (default 2m0s)
       --ntp-server string                          Address of NTP serer used to check clock skew (default "0.pool.ntp.org")
+      --server-write-timeout                       Guard http server write timeout. Default is 10 seconds.
       --secure-addr string                         host:port used to serve secure apis (default ":8443")
       --tls-ca-file string                         File containing CA certificate
       --tls-cert-file string                       File container server TLS certificate

--- a/server/server.go
+++ b/server/server.go
@@ -190,7 +190,7 @@ func (s Server) ListenAndServe() {
 	srv := &http.Server{
 		Addr:         s.AuthRecommendedOptions.SecureServing.SecureAddr,
 		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		WriteTimeout: 25 * time.Second,
 		Handler:      m,
 		TLSConfig:    tlsConfig,
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -45,11 +45,11 @@ type Server struct {
 	AuthRecommendedOptions  *AuthRecommendedOptions
 	AuthzRecommendedOptions *AuthzRecommendedOptions
 	TokenAuthenticator      *token.Authenticator
-	WriteTimeout             time.Duration
+	WriteTimeout            time.Duration
 }
 
 func (s *Server) AddFlags(fs *pflag.FlagSet) {
-	fs.DurationVar(&s.WriteTimeout, "server-write-timeout", 10 * time.Second, "Guard http server write timeout. Default is 10 seconds.")
+	fs.DurationVar(&s.WriteTimeout, "server-write-timeout", 10*time.Second, "Guard http server write timeout. Default is 10 seconds.")
 	s.AuthRecommendedOptions.AddFlags(fs)
 	s.AuthzRecommendedOptions.AddFlags(fs)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -45,9 +45,11 @@ type Server struct {
 	AuthRecommendedOptions  *AuthRecommendedOptions
 	AuthzRecommendedOptions *AuthzRecommendedOptions
 	TokenAuthenticator      *token.Authenticator
+	WriteTimeout             time.Duration
 }
 
 func (s *Server) AddFlags(fs *pflag.FlagSet) {
+	fs.DurationVar(&s.WriteTimeout, "server-write-timeout", 10 * time.Second, "Guard http server write timeout. Default is 10 seconds.")
 	s.AuthRecommendedOptions.AddFlags(fs)
 	s.AuthzRecommendedOptions.AddFlags(fs)
 }
@@ -190,7 +192,7 @@ func (s Server) ListenAndServe() {
 	srv := &http.Server{
 		Addr:         s.AuthRecommendedOptions.SecureServing.SecureAddr,
 		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 25 * time.Second,
+		WriteTimeout: s.WriteTimeout,
 		Handler:      m,
 		TLSConfig:    tlsConfig,
 	}


### PR DESCRIPTION
We have been seeing stream Internal Errors in kube-apiserver for webhook authorizer requests to guard recently. On investigating we found out that it is because the write timeout in guard server is short  (10 secs) and it closes client connection whenever it takes longer than 10s calling to Azure to check access (which is taking more than 10 seconds )
Increasing the write timeout to handle this. 

More on server timeouts: https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/