### PR TITLE
Increase read time out for Guard

### DIFF
--- a/auth/providers/azure/graph/aks_tokenprovider.go
+++ b/auth/providers/azure/graph/aks_tokenprovider.go
@@ -34,7 +34,8 @@ type aksTokenProvider struct {
 // NewAKSTokenProvider returns a TokenProvider that implements On-Behalf-Of flow using AKS first party service
 func NewAKSTokenProvider(tokenURL, tenantID string) TokenProvider {
 	tr := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:               http.ProxyFromEnvironment,
+		MaxIdleConnsPerHost: 100,
 	}
 	return &aksTokenProvider{
 		name:     "AKSTokenProvider",

--- a/auth/providers/azure/graph/clientcredential_tokenprovider.go
+++ b/auth/providers/azure/graph/clientcredential_tokenprovider.go
@@ -40,7 +40,8 @@ type clientCredentialTokenProvider struct {
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#get-a-token
 func NewClientCredentialTokenProvider(clientID, clientSecret, loginURL, scope string) TokenProvider {
 	tr := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:               http.ProxyFromEnvironment,
+		MaxIdleConnsPerHost: 100,
 	}
 	return &clientCredentialTokenProvider{
 		name:         "ClientCredentialTokenProvider",

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -79,7 +79,8 @@ func (u *UserInfo) getGroupIDs(userPrincipal string) ([]string, error) {
 	// Set the auth headers for the request
 	req.Header = u.headers
 	tr := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:               http.ProxyFromEnvironment,
+		MaxIdleConnsPerHost: 100,
 	}
 
 	u.client.Transport = tr

--- a/auth/providers/azure/graph/obo_tokenprovider.go
+++ b/auth/providers/azure/graph/obo_tokenprovider.go
@@ -40,7 +40,8 @@ type oboTokenProvider struct {
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow
 func NewOBOTokenProvider(clientID, clientSecret, loginURL, scope string) TokenProvider {
 	tr := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:               http.ProxyFromEnvironment,
+		MaxIdleConnsPerHost: 100,
 	}
 	return &oboTokenProvider{
 		name:         "OBOTokenProvider",

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -280,7 +280,8 @@ func (a *AccessInfo) CheckAccess(request *authzv1.SubjectAccessReviewSpec) (*aut
 	a.setReqHeaders(req)
 
 	tr := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:               http.ProxyFromEnvironment,
+		MaxIdleConnsPerHost: 100,
 	}
 
 	a.client.Transport = tr

--- a/docs/reference/guard_run.md
+++ b/docs/reference/guard_run.md
@@ -66,6 +66,7 @@ guard run [flags]
       --max-clock-skew duration                    Max acceptable clock skew for server clock (default 2m0s)
       --ntp-server string                          Address of NTP serer used to check clock skew (default "0.pool.ntp.org")
       --server-write-timeout                       Guard http server write timeout. Default is 10 seconds.
+      --server-read-timeout                        Guard http server read timeout. Default is 5 seconds.
       --secure-addr string                         host:port used to serve secure apis (default ":8443")
       --tls-ca-file string                         File containing CA certificate
       --tls-cert-file string                       File container server TLS certificate

--- a/server/server.go
+++ b/server/server.go
@@ -46,10 +46,12 @@ type Server struct {
 	AuthzRecommendedOptions *AuthzRecommendedOptions
 	TokenAuthenticator      *token.Authenticator
 	WriteTimeout            time.Duration
+	ReadTimeout             time.Duration
 }
 
 func (s *Server) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.WriteTimeout, "server-write-timeout", 10*time.Second, "Guard http server write timeout. Default is 10 seconds.")
+	fs.DurationVar(&s.ReadTimeout, "server-read-timeout", 5*time.Second, "Guard http server read timeout. Default is 5 seconds.")
 	s.AuthRecommendedOptions.AddFlags(fs)
 	s.AuthzRecommendedOptions.AddFlags(fs)
 }
@@ -192,7 +194,7 @@ func (s Server) ListenAndServe() {
 
 	srv := &http.Server{
 		Addr:         s.AuthRecommendedOptions.SecureServing.SecureAddr,
-		ReadTimeout:  5 * time.Second,
+		ReadTimeout:  s.ReadTimeout,
 		WriteTimeout: s.WriteTimeout,
 		Handler:      m,
 		TLSConfig:    tlsConfig,


### PR DESCRIPTION
We have been observing various client connection errors due to default values in http client & server.

stream error: stream ID 1; INTERNAL_ERROR; received from peer -> due to aggressive read time out
connect: cannot assign requested address -> due to default MaxIdleConnsPerHost.

Raising PR to fix these by making read time out value configurable.

