### PR TITLE
Add context timeout for checkaccess requests and fix metrics

### DIFF
--- a/authz/providers/azure/azure.go
+++ b/authz/providers/azure/azure.go
@@ -16,6 +16,7 @@ limitations under the License.
 package azure
 
 import (
+	"net/http"
 	"strings"
 	"sync"
 
@@ -24,6 +25,7 @@ import (
 	authzOpts "go.kubeguard.dev/guard/authz/providers/azure/options"
 	"go.kubeguard.dev/guard/authz/providers/azure/rbac"
 	azureutils "go.kubeguard.dev/guard/util/azure"
+	errutils "go.kubeguard.dev/guard/util/error"
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/pkg/errors"
@@ -78,7 +80,7 @@ func newAuthzClient(opts authzOpts.Options, authopts auth.Options, operationsMap
 
 func (s Authorizer) Check(request *authzv1.SubjectAccessReviewSpec, store authz.Store) (*authzv1.SubjectAccessReviewStatus, error) {
 	if request == nil {
-		return nil, errors.New("subject access review is nil")
+		return nil, errutils.WithCode(errors.New("subject access review is nil"), http.StatusBadRequest)
 	}
 
 	// check if user is system accounts

--- a/authz/providers/azure/azure_test.go
+++ b/authz/providers/azure/azure_test.go
@@ -29,6 +29,7 @@ import (
 	authzOpts "go.kubeguard.dev/guard/authz/providers/azure/options"
 	"go.kubeguard.dev/guard/authz/providers/azure/rbac"
 	azureutils "go.kubeguard.dev/guard/util/azure"
+	errutils "go.kubeguard.dev/guard/util/error"
 
 	"github.com/appscode/pat"
 	"github.com/stretchr/testify/assert"
@@ -147,6 +148,9 @@ func TestCheck(t *testing.T) {
 		assert.NotNil(t, resp)
 		assert.Equal(t, resp.Allowed, true)
 		assert.Equal(t, resp.Denied, false)
+		if v, ok := err.(errutils.HttpStatusCode); ok {
+			assert.Equal(t, v.Code(), http.StatusOK)
+		}
 	})
 
 	t.Run("unsuccessful request", func(t *testing.T) {
@@ -167,6 +171,9 @@ func TestCheck(t *testing.T) {
 		assert.Nilf(t, resp, "response should be nil")
 		assert.NotNilf(t, err, "should get error")
 		assert.Contains(t, err.Error(), "Error occured during authorization check")
+		if v, ok := err.(errutils.HttpStatusCode); ok {
+			assert.Equal(t, v.Code(), http.StatusInternalServerError)
+		}
 	})
 
 	t.Run("context timeout request", func(t *testing.T) {
@@ -187,5 +194,8 @@ func TestCheck(t *testing.T) {
 		assert.Nilf(t, resp, "response should be nil")
 		assert.NotNilf(t, err, "should get error")
 		assert.Contains(t, err.Error(), "Checkaccess requests have timed out")
+		if v, ok := err.(errutils.HttpStatusCode); ok {
+			assert.Equal(t, v.Code(), http.StatusInternalServerError)
+		}
 	})
 }

--- a/authz/providers/azure/azure_test.go
+++ b/authz/providers/azure/azure_test.go
@@ -71,7 +71,7 @@ func clientSetup(serverUrl, mode string) (*Authorizer, error) {
 	return c, nil
 }
 
-func serverSetup(loginResp, checkaccessResp string, loginStatus, checkaccessStatus int) (*httptest.Server, error) {
+func serverSetup(loginResp, checkaccessResp string, loginStatus, checkaccessStatus int, sleepFor time.Duration) (*httptest.Server, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:")
 	if err != nil {
 		return nil, err
@@ -85,6 +85,7 @@ func serverSetup(loginResp, checkaccessResp string, loginStatus, checkaccessStat
 	}))
 
 	m.Post("/arm/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(sleepFor)
 		w.WriteHeader(checkaccessStatus)
 		_, _ = w.Write([]byte(checkaccessResp))
 	}))
@@ -98,8 +99,8 @@ func serverSetup(loginResp, checkaccessResp string, loginStatus, checkaccessStat
 	return srv, nil
 }
 
-func getServerAndClient(t *testing.T, loginResp, checkaccessResp string, checkaccessStatus int) (*httptest.Server, *Authorizer, authz.Store) {
-	srv, err := serverSetup(loginResp, checkaccessResp, http.StatusOK, checkaccessStatus)
+func getServerAndClient(t *testing.T, loginResp, checkaccessResp string, checkaccessStatus int, sleepFor time.Duration) (*httptest.Server, *Authorizer, authz.Store) {
+	srv, err := serverSetup(loginResp, checkaccessResp, http.StatusOK, checkaccessStatus, sleepFor)
 	if err != nil {
 		t.Fatalf("Error when creating server, reason: %v", err)
 	}
@@ -129,7 +130,7 @@ func TestCheck(t *testing.T) {
 		"actionId":"Microsoft.Kubernetes/connectedClusters/pods/delete",
 		"isDataAction":true,"roleAssignment":null,"denyAssignment":null,"timeToLiveInMs":300000}]`
 
-		srv, client, store := getServerAndClient(t, loginResp, validBody, http.StatusOK)
+		srv, client, store := getServerAndClient(t, loginResp, validBody, http.StatusOK, 1*time.Second)
 		defer srv.Close()
 		defer store.Close()
 
@@ -150,7 +151,7 @@ func TestCheck(t *testing.T) {
 
 	t.Run("unsuccessful request", func(t *testing.T) {
 		validBody := `""`
-		srv, client, store := getServerAndClient(t, loginResp, validBody, http.StatusInternalServerError)
+		srv, client, store := getServerAndClient(t, loginResp, validBody, http.StatusInternalServerError, 1*time.Second)
 		defer srv.Close()
 		defer store.Close()
 
@@ -166,5 +167,25 @@ func TestCheck(t *testing.T) {
 		assert.Nilf(t, resp, "response should be nil")
 		assert.NotNilf(t, err, "should get error")
 		assert.Contains(t, err.Error(), "Error occured during authorization check")
+	})
+
+	t.Run("context timeout request", func(t *testing.T) {
+		validBody := `""`
+		srv, client, store := getServerAndClient(t, loginResp, validBody, http.StatusInternalServerError, 25*time.Second)
+		defer srv.Close()
+		defer store.Close()
+
+		request := &authzv1.SubjectAccessReviewSpec{
+			User: "beta@bing.com",
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Namespace: "dev", Group: "", Resource: "pods",
+				Subresource: "status", Version: "v1", Name: "test", Verb: "delete",
+			}, Extra: map[string]authzv1.ExtraValue{"oid": {"00000000-0000-0000-0000-000000000000"}},
+		}
+
+		resp, err := client.Check(request, store)
+		assert.Nilf(t, resp, "response should be nil")
+		assert.NotNilf(t, err, "should get error")
+		assert.Contains(t, err.Error(), "Checkaccess requests have timed out")
 	})
 }

--- a/authz/providers/azure/rbac/checkaccessreqhelper.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper.go
@@ -443,7 +443,7 @@ func getResultCacheKey(subRevReq *authzv1.SubjectAccessReviewSpec) string {
 	return cacheKey
 }
 
-func prepareCheckAccessRequestBody(req *authzv1.SubjectAccessReviewSpec, clusterType string, operationsMap azureutils.OperationsMap, resourceId string, useNamespaceResourceScopeFormat bool) ([]*CheckAccessRequest, *azureutils.Error) {
+func prepareCheckAccessRequestBody(req *authzv1.SubjectAccessReviewSpec, clusterType string, operationsMap azureutils.OperationsMap, resourceId string, useNamespaceResourceScopeFormat bool) ([]*CheckAccessRequest, error) {
 	/* This is how sample SubjectAccessReview request will look like
 		{
 			"kind": "SubjectAccessReview",
@@ -508,20 +508,6 @@ func prepareCheckAccessRequestBody(req *authzv1.SubjectAccessReviewSpec, cluster
 		return nil, errutils.WithCode(errors.Wrap(err, "Error while creating list of dataactions for check access call"), http.StatusInternalServerError)
 	}
 	var checkAccessReqs []*CheckAccessRequest
-	for i := 0; i < len(actions); i += ActionBatchCount {
-		j := i + ActionBatchCount
-		if j > len(actions) {
-			j = len(actions)
-		}
-
-		checkaccessreq := CheckAccessRequest{}
-		checkaccessreq.Subject.Attributes.Groups = groups
-		checkaccessreq.Subject.Attributes.ObjectId = userOid
-		checkaccessreq.Actions = actions[i:j]
-		checkaccessreq.Resource.Id = getScope(resourceId, req.ResourceAttributes, useNamespaceResourceScopeFormat)
-		checkAccessReqs = append(checkAccessReqs, &checkaccessreq)
-	}
-
 	for i := 0; i < len(actions); i += ActionBatchCount {
 		j := i + ActionBatchCount
 		if j > len(actions) {

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -64,8 +64,10 @@ type AuthzInfo struct {
 	ARMEndPoint string
 }
 
-type void struct{}
-type correlationRequestIDKey string
+type (
+	void                    struct{}
+	correlationRequestIDKey string
+)
 
 // AccessInfo allows you to check user access from MS RBAC
 type AccessInfo struct {
@@ -318,7 +320,7 @@ func (a *AccessInfo) CheckAccess(request *authzv1.SubjectAccessReviewSpec) (*aut
 	for _, checkAccessBody := range checkAccessBodies {
 		body := checkAccessBody
 		eg.Go(func() error {
-			//create a request id for every checkaccess request
+			// create a request id for every checkaccess request
 			requestUUID := uuid.New()
 			reqContext := context.WithValue(egCtx, correlationRequestIDKey(correlationRequestIDHeader), []string{requestUUID.String()})
 			err := a.sendCheckAccessRequest(reqContext, checkAccessURL, body, ch)
@@ -383,7 +385,7 @@ func (a *AccessInfo) sendCheckAccessRequest(ctx context.Context, checkAccessURL 
 	}
 
 	a.setReqHeaders(req)
-	//set x-ms-correlation-request-id for the checkaccess request
+	// set x-ms-correlation-request-id for the checkaccess request
 	correlationID := ctx.Value(correlationRequestIDKey(correlationRequestIDHeader)).([]string)
 	req.Header[correlationRequestIDHeader] = correlationID
 	internalServerCode := azureutils.ConvertIntToString(http.StatusInternalServerError)

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -329,7 +329,7 @@ func (a *AccessInfo) CheckAccess(request *authzv1.SubjectAccessReviewSpec) (*aut
 				if v, ok := err.(errutils.HttpStatusCode); ok {
 					code = v.Code()
 				}
-				err = errutils.WithCode(errors.Errorf("Correlation ID: %s. Error: %s", requestUUID.String(), err), code)
+				err = errutils.WithCode(errors.Errorf("Error: %s. Correlation ID: %s", requestUUID.String(), err), code)
 				return err
 			}
 			return nil
@@ -338,7 +338,7 @@ func (a *AccessInfo) CheckAccess(request *authzv1.SubjectAccessReviewSpec) (*aut
 
 	if err := eg.Wait(); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			klog.V(5).Infof("Checkaccess requests have timed out. Error: %v\n", ctx.Err())
+			klog.V(5).Infof("Checkaccess requests have timed out. Error: %v", ctx.Err())
 			actionsCount := 0
 			for i := 0; i < len(checkAccessBodies); i += 1 {
 				actionsCount = actionsCount + len(checkAccessBodies[i].Actions)

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	golang.org/x/exp v0.0.0-20221026004748-78e5e7837ae6
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/sync v0.1.0
 	golang.org/x/text v0.3.7
 	gomodules.xyz/blobfs v0.1.7
 	gomodules.xyz/cert v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -631,6 +631,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/server/authzhandler.go
+++ b/server/authzhandler.go
@@ -19,11 +19,11 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/pkg/errors"
 	"go.kubeguard.dev/guard/authz"
 	"go.kubeguard.dev/guard/authz/providers/azure"
 	azureutils "go.kubeguard.dev/guard/util/azure"
-
-	"github.com/pkg/errors"
+	errutils "go.kubeguard.dev/guard/util/error"
 	authzv1 "k8s.io/api/authorization/v1"
 	"k8s.io/klog/v2"
 )
@@ -38,12 +38,12 @@ type Authzhandler struct {
 func (s *Authzhandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	klog.Infof("Recieved subject access review request")
 	if req.TLS == nil || len(req.TLS.PeerCertificates) == 0 {
-		writeAuthzResponse(w, nil, nil, WithCode(errors.New("Missing client certificate"), http.StatusBadRequest))
+		writeAuthzResponse(w, nil, nil, errutils.WithCode(errors.New("Missing client certificate"), http.StatusBadRequest))
 		return
 	}
 	crt := req.TLS.PeerCertificates[0]
 	if len(crt.Subject.Organization) == 0 {
-		writeAuthzResponse(w, nil, nil, WithCode(errors.New("Client certificate is missing organization"), http.StatusBadRequest))
+		writeAuthzResponse(w, nil, nil, errutils.WithCode(errors.New("Client certificate is missing organization"), http.StatusBadRequest))
 		return
 	}
 	org := crt.Subject.Organization[0]
@@ -51,18 +51,18 @@ func (s *Authzhandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	data := authzv1.SubjectAccessReview{}
 	err := json.NewDecoder(req.Body).Decode(&data)
 	if err != nil {
-		writeAuthzResponse(w, nil, nil, WithCode(errors.Wrap(err, "Failed to parse request"), http.StatusBadRequest))
+		writeAuthzResponse(w, nil, nil, errutils.WithCode(errors.Wrap(err, "Failed to parse request"), http.StatusBadRequest))
 		return
 	}
 
 	if !s.AuthzRecommendedOptions.AuthzProvider.Has(org) {
-		writeAuthzResponse(w, &data.Spec, nil, WithCode(errors.Errorf("guard does not provide service for %v", org), http.StatusBadRequest))
+		writeAuthzResponse(w, &data.Spec, nil, errutils.WithCode(errors.Errorf("guard does not provide service for %v", org), http.StatusBadRequest))
 		return
 	}
 
 	client, err := s.getAuthzProviderClient(org)
 	if client == nil || err != nil {
-		writeAuthzResponse(w, &data.Spec, nil, err)
+		writeAuthzResponse(w, &data.Spec, nil, errutils.WithCode(err, http.StatusInternalServerError))
 		return
 	}
 

--- a/server/authzhandler.go
+++ b/server/authzhandler.go
@@ -19,11 +19,12 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/pkg/errors"
 	"go.kubeguard.dev/guard/authz"
 	"go.kubeguard.dev/guard/authz/providers/azure"
 	azureutils "go.kubeguard.dev/guard/util/azure"
 	errutils "go.kubeguard.dev/guard/util/error"
+
+	"github.com/pkg/errors"
 	authzv1 "k8s.io/api/authorization/v1"
 	"k8s.io/klog/v2"
 )

--- a/server/handler.go
+++ b/server/handler.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/pkg/errors"
 	"go.kubeguard.dev/guard/auth"
 	"go.kubeguard.dev/guard/auth/providers/azure"
 	"go.kubeguard.dev/guard/auth/providers/github"
@@ -29,6 +28,8 @@ import (
 	"go.kubeguard.dev/guard/auth/providers/ldap"
 	"go.kubeguard.dev/guard/auth/providers/token"
 	errutils "go.kubeguard.dev/guard/util/error"
+
+	"github.com/pkg/errors"
 	authv1 "k8s.io/api/authentication/v1"
 	"k8s.io/klog/v2"
 )

--- a/server/prometheus.go
+++ b/server/prometheus.go
@@ -49,7 +49,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "request_duration_seconds",
 			Help:    "A histogram of latencies for requests.",
-			Buckets: []float64{.25, .5, 1, 2.5, 5, 10},
+			Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 15, 20},
 		},
 		[]string{"handler", "method"},
 	)
@@ -67,13 +67,13 @@ var (
 
 	inFlightGaugeAuthz = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "subjectaccessreviews_handler_requests_in_flight",
-		Help: "A gauge of requests currently being served by the tokenreviews handler.",
+		Help: "A gauge of requests currently being served by the subjectaccessreviews handler.",
 	})
 
 	counterAuthz = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "subjectaccessreviews_handler_requests_total",
-			Help: "A counter for requests to the tokenreviews handler.",
+			Help: "A counter for requests to the subjectaccessreviews handler.",
 		},
 		[]string{"code", "method"},
 	)

--- a/server/server.go
+++ b/server/server.go
@@ -229,11 +229,16 @@ func (s Server) ListenAndServe() {
 					klog.Fatalf("Failed to create settings for discovering resources. Error:%s", err)
 				}
 
+				discoverResourcesListStart := time.Now()
 				operationsMap, err := azureutils.DiscoverResources(settings)
+				discoverResourcesDuration := time.Since(discoverResourcesListStart).Seconds()
 				if err != nil {
+					azureutils.CounterDiscoverResources.WithLabelValues(azureutils.ConvertIntToString(http.StatusInternalServerError)).Inc()
 					klog.Fatalf("Failed to create map of data actions. Error:%s", err)
 				}
 
+				azureutils.DiscoverResourcesTotalDuration.Observe(discoverResourcesDuration)
+				azureutils.CounterDiscoverResources.WithLabelValues(azureutils.ConvertIntToString(http.StatusOK)).Inc()
 				authzhandler.operationsMap = operationsMap
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -233,12 +233,11 @@ func (s Server) ListenAndServe() {
 				operationsMap, err := azureutils.DiscoverResources(settings)
 				discoverResourcesDuration := time.Since(discoverResourcesListStart).Seconds()
 				if err != nil {
-					azureutils.CounterDiscoverResources.WithLabelValues(azureutils.ConvertIntToString(http.StatusInternalServerError)).Inc()
+					azureutils.DiscoverResourcesTotalDuration.Observe(discoverResourcesDuration)
 					klog.Fatalf("Failed to create map of data actions. Error:%s", err)
 				}
 
 				azureutils.DiscoverResourcesTotalDuration.Observe(discoverResourcesDuration)
-				azureutils.CounterDiscoverResources.WithLabelValues(azureutils.ConvertIntToString(http.StatusOK)).Inc()
 				authzhandler.operationsMap = operationsMap
 			}
 		}

--- a/util/azure/utils.go
+++ b/util/azure/utils.go
@@ -21,7 +21,9 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"strconv"
 	"strings"
+	"time"
 
 	"go.kubeguard.dev/guard/auth/providers/azure/graph"
 	"go.kubeguard.dev/guard/util/httpclient"
@@ -29,6 +31,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	v "gomodules.xyz/x/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -45,6 +48,45 @@ const (
 	ConnectedClusters           = "Microsoft.Kubernetes/connectedClusters"
 	OperationsEndpointFormatARC = "%s/providers/Microsoft.Kubernetes/operations?api-version=2021-10-01"
 	OperationsEndpointFormatAKS = "%s/providers/Microsoft.ContainerService/operations?api-version=2018-10-31"
+)
+
+var (
+	discoverResourcesApiServerCallDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "guard_apiresources_request_duration_seconds",
+			Help:    "A histogram of latencies for apiserver requests.",
+			Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 15, 20},
+		})
+
+	discoverResourcesAzureCallDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "guard_azure_get_operations_request_duration_seconds",
+			Help:    "A histogram of latencies for azure get operations requests.",
+			Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 15, 20},
+		})
+
+	DiscoverResourcesTotalDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "guard_discover_resources_request_duration_seconds",
+			Help:    "A histogram of latencies for azure get operations requests.",
+			Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 15, 20},
+		})
+
+	CounterDiscoverResources = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "guard_discover_requests_requests_total",
+			Help: "A counter for discover resources.",
+		},
+		[]string{"code"},
+	)
+
+	counterGetOperationsResources = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "guard_azure_get_operations_requests_total",
+			Help: "A counter for get operations call in discover resources.",
+		},
+		[]string{"code"},
+	)
 )
 
 type TokenResponse struct {
@@ -132,6 +174,10 @@ func (o OperationsMap) String() string {
 	return string(opMapString)
 }
 
+func ConvertIntToString(number int) string {
+	return strconv.Itoa(number)
+}
+
 func NewDiscoverResourcesSettings(clusterType string, environment string, loginURL string, kubeconfigFilePath string, tenantID string, clientID string, clientSecret string) (*DiscoverResourcesSettings, error) {
 	settings := &DiscoverResourcesSettings{
 		clusterType:        clusterType,
@@ -176,15 +222,25 @@ func NewDiscoverResourcesSettings(clusterType string, environment string, loginU
 */
 func DiscoverResources(settings *DiscoverResourcesSettings) (OperationsMap, error) {
 	operationsMap := OperationsMap{}
+	apiResourcesListStart := time.Now()
 	apiResourcesList, err := fetchApiResources(settings)
+	apiResourcesListDuration := time.Since(apiResourcesListStart).Seconds()
+
 	if err != nil {
 		return operationsMap, errors.Wrap(err, "Failed to fetch list of api-resources from apiserver.")
 	}
 
+	discoverResourcesApiServerCallDuration.Observe(apiResourcesListDuration)
+
+	getOperationsStart := time.Now()
 	operationsList, err := fetchDataActionsList(settings)
+	getOperationsDuration := time.Since(getOperationsStart).Seconds()
+
 	if err != nil {
 		return operationsMap, errors.Wrap(err, "Failed to fetch operations from Azure.")
 	}
+
+	discoverResourcesAzureCallDuration.Observe(getOperationsDuration)
 
 	operationsMap = createOperationsMap(apiResourcesList, operationsList, settings.clusterType)
 
@@ -349,6 +405,7 @@ func fetchDataActionsList(settings *DiscoverResourcesSettings) ([]Operation, err
 
 	resp, err := client.Do(req)
 	if err != nil {
+		counterGetOperationsResources.WithLabelValues(ConvertIntToString(http.StatusInternalServerError)).Inc()
 		return nil, errors.Wrap(err, "Failed to send request for Get Operations call.")
 	}
 	defer resp.Body.Close()
@@ -359,8 +416,11 @@ func fetchDataActionsList(settings *DiscoverResourcesSettings) ([]Operation, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		counterGetOperationsResources.WithLabelValues(ConvertIntToString(resp.StatusCode)).Inc()
 		return nil, errors.Errorf("Request failed with status code: %d and response: %s", resp.StatusCode, string(data))
 	}
+
+	counterGetOperationsResources.WithLabelValues(ConvertIntToString(resp.StatusCode)).Inc()
 
 	operationsList := OperationList{}
 	err = json.Unmarshal(data, &operationsList)
@@ -382,4 +442,8 @@ func fetchDataActionsList(settings *DiscoverResourcesSettings) ([]Operation, err
 	}
 
 	return finalOperations, nil
+}
+
+func init() {
+	prometheus.MustRegister(DiscoverResourcesTotalDuration, discoverResourcesAzureCallDuration, discoverResourcesApiServerCallDuration, CounterDiscoverResources)
 }

--- a/util/azure/utils.go
+++ b/util/azure/utils.go
@@ -71,22 +71,6 @@ var (
 			Help:    "A histogram of latencies for azure get operations requests.",
 			Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 15, 20},
 		})
-
-	CounterDiscoverResources = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "guard_discover_requests_requests_total",
-			Help: "A counter for discover resources.",
-		},
-		[]string{"code"},
-	)
-
-	counterGetOperationsResources = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "guard_azure_get_operations_requests_total",
-			Help: "A counter for get operations call in discover resources.",
-		},
-		[]string{"code"},
-	)
 )
 
 type TokenResponse struct {
@@ -405,7 +389,6 @@ func fetchDataActionsList(settings *DiscoverResourcesSettings) ([]Operation, err
 
 	resp, err := client.Do(req)
 	if err != nil {
-		counterGetOperationsResources.WithLabelValues(ConvertIntToString(http.StatusInternalServerError)).Inc()
 		return nil, errors.Wrap(err, "Failed to send request for Get Operations call.")
 	}
 	defer resp.Body.Close()
@@ -416,11 +399,8 @@ func fetchDataActionsList(settings *DiscoverResourcesSettings) ([]Operation, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		counterGetOperationsResources.WithLabelValues(ConvertIntToString(resp.StatusCode)).Inc()
 		return nil, errors.Errorf("Request failed with status code: %d and response: %s", resp.StatusCode, string(data))
 	}
-
-	counterGetOperationsResources.WithLabelValues(ConvertIntToString(resp.StatusCode)).Inc()
 
 	operationsList := OperationList{}
 	err = json.Unmarshal(data, &operationsList)
@@ -445,5 +425,5 @@ func fetchDataActionsList(settings *DiscoverResourcesSettings) ([]Operation, err
 }
 
 func init() {
-	prometheus.MustRegister(DiscoverResourcesTotalDuration, discoverResourcesAzureCallDuration, discoverResourcesApiServerCallDuration, CounterDiscoverResources)
+	prometheus.MustRegister(DiscoverResourcesTotalDuration, discoverResourcesAzureCallDuration, discoverResourcesApiServerCallDuration)
 }

--- a/util/error/utils.go
+++ b/util/error/utils.go
@@ -19,6 +19,7 @@ package error
 import (
 	"fmt"
 	"io"
+
 	"k8s.io/klog/v2"
 )
 
@@ -42,6 +43,10 @@ type withCode struct {
 func (w *withCode) Error() string { return w.cause.Error() }
 func (w *withCode) Cause() error  { return w.cause }
 func (w *withCode) Code() int     { return w.code }
+
+type HttpStatusCode interface {
+	Code() int
+}
 
 func (w *withCode) Format(s fmt.State, verb rune) {
 	switch verb {

--- a/util/error/utils.go
+++ b/util/error/utils.go
@@ -1,0 +1,63 @@
+/*
+Copyright The Guard Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package error
+
+import (
+	"fmt"
+	"io"
+	"k8s.io/klog/v2"
+)
+
+// WithCode annotates err with a new code.
+// If err is nil, WithCode returns nil.
+func WithCode(err error, code int) error {
+	if err == nil {
+		return nil
+	}
+	return &withCode{
+		cause: err,
+		code:  code,
+	}
+}
+
+type withCode struct {
+	cause error
+	code  int
+}
+
+func (w *withCode) Error() string { return w.cause.Error() }
+func (w *withCode) Cause() error  { return w.cause }
+func (w *withCode) Code() int     { return w.code }
+
+func (w *withCode) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			_, err := fmt.Fprintf(s, "%+v\n", w.Cause())
+			if err != nil {
+				klog.Fatal(err)
+			}
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		_, err := io.WriteString(s, w.Error())
+		if err != nil {
+			klog.Fatal(err)
+		}
+	}
+}

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,132 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type token struct{}
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid, has no limit on the number of active goroutines,
+// and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	sem chan token
+
+	errOnce sync.Once
+	err     error
+}
+
+func (g *Group) done() {
+	if g.sem != nil {
+		<-g.sem
+	}
+	g.wg.Done()
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+// It blocks until the new goroutine can be added without the number of
+// active goroutines in the group exceeding the configured limit.
+//
+// The first call to return a non-nil error cancels the group's context, if the
+// group was created by calling WithContext. The error will be returned by Wait.
+func (g *Group) Go(f func() error) {
+	if g.sem != nil {
+		g.sem <- token{}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}
+
+// TryGo calls the given function in a new goroutine only if the number of
+// active goroutines in the group is currently below the configured limit.
+//
+// The return value reports whether the goroutine was started.
+func (g *Group) TryGo(f func() error) bool {
+	if g.sem != nil {
+		select {
+		case g.sem <- token{}:
+			// Note: this allows barging iff channels in general allow barging.
+		default:
+			return false
+		}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+	return true
+}
+
+// SetLimit limits the number of active goroutines in this group to at most n.
+// A negative value indicates no limit.
+//
+// Any subsequent call to the Go method will block until it can add an active
+// goroutine without exceeding the configured limit.
+//
+// The limit must not be modified while any goroutines in the group are active.
+func (g *Group) SetLimit(n int) {
+	if n < 0 {
+		g.sem = nil
+		return
+	}
+	if len(g.sem) != 0 {
+		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", len(g.sem)))
+	}
+	g.sem = make(chan token, n)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -443,6 +443,9 @@ golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
+# golang.org/x/sync v0.1.0
+## explicit
+golang.org/x/sync/errgroup
 # golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
 ## explicit; go 1.17
 golang.org/x/sys/internal/unsafeheader


### PR DESCRIPTION
Context timeout - 
Change to using https://pkg.go.dev/golang.org/x/sync/errgroup which can propagate error , it is a wrapper on waitgroups. Added a context timeout of 23 seconds.

Added contexttimeout metric as well

Discover Resources metrics:
Added metrics for  - 
1. Total duration for discovering resources which includes both apiserver and get operations call
2. Duration for apiserver call
3. Duration for get operations call

Fix metrics:
1. SAR status was returning 200 code regardless of whether there were any errors or not. Utilized existing withCode struct to make sure we send an appropriate errorcode. The divisions of errorcode are:
a. if checkaccess fails , we will send back errorcode which will be the response status code.
b. if it's any other error it will either be statusbadrequest if client related or statusInternalServerError otherwise

7. Fixed checkaccess requests total and failed metrics to included statuscode as a dimension. This will help us get the success rate
8. Added metrics for checkaccess latency as well 