### PR TITLE
Add support for reconciling discover resources

### DIFF
--- a/authz/providers/azure/azure.go
+++ b/authz/providers/azure/azure.go
@@ -25,7 +25,6 @@ import (
 	"go.kubeguard.dev/guard/authz"
 	authzOpts "go.kubeguard.dev/guard/authz/providers/azure/options"
 	"go.kubeguard.dev/guard/authz/providers/azure/rbac"
-	azureutils "go.kubeguard.dev/guard/util/azure"
 	errutils "go.kubeguard.dev/guard/util/error"
 
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -52,10 +51,10 @@ type Authorizer struct {
 	rbacClient *rbac.AccessInfo
 }
 
-func New(opts authzOpts.Options, authopts auth.Options, operationsMap azureutils.OperationsMap) (authz.Interface, error) {
+func New(opts authzOpts.Options, authopts auth.Options) (authz.Interface, error) {
 	once.Do(func() {
 		klog.Info("Creating Azure global authz client")
-		client, err = newAuthzClient(opts, authopts, operationsMap)
+		client, err = newAuthzClient(opts, authopts)
 		if client == nil || err != nil {
 			klog.Fatalf("Authz RBAC client creation failed. Error: %s", err)
 		}
@@ -63,7 +62,7 @@ func New(opts authzOpts.Options, authopts auth.Options, operationsMap azureutils
 	return client, err
 }
 
-func newAuthzClient(opts authzOpts.Options, authopts auth.Options, operationsMap azureutils.OperationsMap) (authz.Interface, error) {
+func newAuthzClient(opts authzOpts.Options, authopts auth.Options) (authz.Interface, error) {
 	c := &Authorizer{}
 
 	authzInfoVal, err := getAuthzInfo(authopts.Environment)
@@ -71,7 +70,7 @@ func newAuthzClient(opts authzOpts.Options, authopts auth.Options, operationsMap
 		return nil, errors.Wrap(err, "Error in getAuthzInfo %s")
 	}
 
-	c.rbacClient, err = rbac.New(opts, authopts, authzInfoVal, operationsMap)
+	c.rbacClient, err = rbac.New(opts, authopts, authzInfoVal)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create ms rbac client")
 	}

--- a/authz/providers/azure/azure_test.go
+++ b/authz/providers/azure/azure_test.go
@@ -28,7 +28,6 @@ import (
 	"go.kubeguard.dev/guard/authz/providers/azure/data"
 	authzOpts "go.kubeguard.dev/guard/authz/providers/azure/options"
 	"go.kubeguard.dev/guard/authz/providers/azure/rbac"
-	azureutils "go.kubeguard.dev/guard/util/azure"
 	errutils "go.kubeguard.dev/guard/util/error"
 
 	"github.com/go-chi/chi/v5"
@@ -62,9 +61,7 @@ func clientSetup(serverUrl, mode string) (*Authorizer, error) {
 		ARMEndPoint: serverUrl + "/arm/",
 	}
 
-	dataActionsMap := azureutils.OperationsMap{}
-
-	c.rbacClient, err = rbac.New(opts, authOpts, &authzInfo, dataActionsMap)
+	c.rbacClient, err = rbac.New(opts, authOpts, &authzInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/authz/providers/azure/options/options.go
+++ b/authz/providers/azure/options/options.go
@@ -19,6 +19,7 @@ package options
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"go.kubeguard.dev/guard/auth/providers/azure"
 
@@ -37,26 +38,28 @@ const (
 )
 
 type Options struct {
-	AuthzMode                       string
-	ResourceId                      string
-	AKSAuthzTokenURL                string
-	ARMCallLimit                    int
-	SkipAuthzCheck                  []string
-	SkipAuthzForNonAADUsers         bool
-	AllowNonResDiscoveryPathAccess  bool
-	UseNamespaceResourceScopeFormat bool
-	DiscoverResources               bool
-	KubeConfigFile                  string
+	AuthzMode                           string
+	ResourceId                          string
+	AKSAuthzTokenURL                    string
+	ARMCallLimit                        int
+	SkipAuthzCheck                      []string
+	SkipAuthzForNonAADUsers             bool
+	AllowNonResDiscoveryPathAccess      bool
+	UseNamespaceResourceScopeFormat     bool
+	DiscoverResources                   bool
+	ReconcileDiscoverResourcesFrequency time.Duration
+	KubeConfigFile                      string
 }
 
 func NewOptions() Options {
 	return Options{
-		ARMCallLimit:                    defaultArmCallLimit,
-		SkipAuthzCheck:                  []string{""},
-		SkipAuthzForNonAADUsers:         true,
-		AllowNonResDiscoveryPathAccess:  true,
-		UseNamespaceResourceScopeFormat: false,
-		DiscoverResources:               false,
+		ARMCallLimit:                        defaultArmCallLimit,
+		SkipAuthzCheck:                      []string{""},
+		SkipAuthzForNonAADUsers:             true,
+		AllowNonResDiscoveryPathAccess:      true,
+		UseNamespaceResourceScopeFormat:     false,
+		DiscoverResources:                   false,
+		ReconcileDiscoverResourcesFrequency: 10 * time.Minute,
 	}
 }
 
@@ -71,6 +74,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.UseNamespaceResourceScopeFormat, "azure.use-ns-resource-scope-format", o.UseNamespaceResourceScopeFormat, "use namespace as resource scope format for making rbac checkaccess calls at namespace scope")
 	fs.StringVar(&o.KubeConfigFile, "azure.kubeconfig-file", "", "path to the kubeconfig of cluster.")
 	fs.BoolVar(&o.DiscoverResources, "azure.discover-resources", o.DiscoverResources, "fetch list of resources and operations from apiserver and azure. Default: false")
+	fs.DurationVar(&o.ReconcileDiscoverResourcesFrequency, "azure.discover-resources-frequency", o.ReconcileDiscoverResourcesFrequency, "Frequency at which discover resources should be reconciled. Default: 5m")
 }
 
 func (o *Options) Validate(azure azure.Options) []error {

--- a/authz/providers/azure/options/options.go
+++ b/authz/providers/azure/options/options.go
@@ -59,7 +59,7 @@ func NewOptions() Options {
 		AllowNonResDiscoveryPathAccess:      true,
 		UseNamespaceResourceScopeFormat:     false,
 		DiscoverResources:                   false,
-		ReconcileDiscoverResourcesFrequency: 10 * time.Minute,
+		ReconcileDiscoverResourcesFrequency: 5 * time.Minute,
 	}
 }
 

--- a/authz/providers/azure/rbac/checkaccessreqhelper.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper.go
@@ -49,7 +49,7 @@ const (
 
 var (
 	username               string
-	getStoredOperationsMap = azureutils.GetOperationsMap
+	getStoredOperationsMap = azureutils.DeepCopyOperationsMap
 )
 
 type SubjectInfoAttributes struct {
@@ -269,15 +269,13 @@ func getAuthInfoListForWildcard(subRevReq *authzv1.SubjectAccessReviewSpec, stor
 	var authInfoList []azureutils.AuthorizationActionInfo
 	var err error
 	finalFilteredOperations := azureutils.NewOperationsMap()
-	azureutils.RLockOperationsMap()
-	defer azureutils.RUnlockOperationsMap()
 	if subRevReq.ResourceAttributes.Resource == "*" {
 		/*
 			This sections handles the following scenarios:
 
 			| Scenario              | Namespace is empty (Cluster scope call)                    | Namespace is not empty (NS scope)             |
 			------------------------ ------------------------------------------------------------  ----------------------------------------------
-			| Verb-*, Res-*, Gro
+			| Verb-*, Res-*, Group-*| All cluster and ns res with all verbs at clusterscope | All ns resources at ns scope |
 
 			| Res-*, Group-*        | All cluster and ns res with specified verb at clusterscope | All ns res with specified verb at ns scope    |
 

--- a/authz/providers/azure/rbac/checkaccessreqhelper_test.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper_test.go
@@ -30,8 +30,8 @@ import (
 
 const resourceId = "resourceId"
 
-func createOperationsMap(clusterType string) {
-	azureutils.GlobalOperationsMap = azureutils.OperationsMap{
+func createOperationsMap(clusterType string) azureutils.OperationsMap {
+	return azureutils.OperationsMap{
 		"apps": azureutils.ResourceAndVerbMap{
 			"deployments": azureutils.VerbAndActionsMap{
 				"read":   azureutils.DataAction{ActionInfo: azureutils.AuthorizationActionInfo{AuthorizationEntity: azureutils.AuthorizationEntity{Id: fmt.Sprintf("%s/apps/deployments/read", clusterType)}, IsDataAction: true}, IsNamespacedResource: true},
@@ -477,7 +477,10 @@ func Test_getDataActions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			createOperationsMap(tt.args.clusterType)
+			operationsMap := createOperationsMap(tt.args.clusterType)
+			getStoredOperationsMap = func() azureutils.OperationsMap {
+				return operationsMap
+			}
 			got, _ := getDataActions(tt.args.subRevReq, tt.args.clusterType)
 			if !tt.args.isWildcardTest && !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getDataActions() = %v, want %v", got, tt.want)

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -87,7 +87,6 @@ type AccessInfo struct {
 	allowNonResDiscoveryPathAccess  bool
 	useNamespaceResourceScopeFormat bool
 	lock                            sync.RWMutex
-	operationsMap                   azureutils.OperationsMap
 }
 
 var (
@@ -156,7 +155,7 @@ func getClusterType(clsType string) string {
 	}
 }
 
-func newAccessInfo(tokenProvider graph.TokenProvider, rbacURL *url.URL, opts authzOpts.Options, operationsMap azureutils.OperationsMap) (*AccessInfo, error) {
+func newAccessInfo(tokenProvider graph.TokenProvider, rbacURL *url.URL, opts authzOpts.Options) (*AccessInfo, error) {
 	u := &AccessInfo{
 		client: httpclient.DefaultHTTPClient,
 		headers: http.Header{
@@ -180,14 +179,12 @@ func newAccessInfo(tokenProvider graph.TokenProvider, rbacURL *url.URL, opts aut
 
 	u.clusterType = getClusterType(opts.AuthzMode)
 
-	u.operationsMap = operationsMap
-
 	u.lock = sync.RWMutex{}
 
 	return u, nil
 }
 
-func New(opts authzOpts.Options, authopts auth.Options, authzInfo *AuthzInfo, operationsMap azureutils.OperationsMap) (*AccessInfo, error) {
+func New(opts authzOpts.Options, authopts auth.Options, authzInfo *AuthzInfo) (*AccessInfo, error) {
 	rbacURL, err := url.Parse(authzInfo.ARMEndPoint)
 	if err != nil {
 		return nil, err
@@ -205,7 +202,7 @@ func New(opts authzOpts.Options, authopts auth.Options, authzInfo *AuthzInfo, op
 		tokenProvider = graph.NewAKSTokenProvider(opts.AKSAuthzTokenURL, authopts.TenantID)
 	}
 
-	return newAccessInfo(tokenProvider, rbacURL, opts, operationsMap)
+	return newAccessInfo(tokenProvider, rbacURL, opts)
 }
 
 func (a *AccessInfo) RefreshToken() error {
@@ -291,7 +288,7 @@ func (a *AccessInfo) setReqHeaders(req *http.Request) {
 }
 
 func (a *AccessInfo) CheckAccess(request *authzv1.SubjectAccessReviewSpec) (*authzv1.SubjectAccessReviewStatus, error) {
-	checkAccessBodies, err := prepareCheckAccessRequestBody(request, a.clusterType, a.operationsMap, a.azureResourceId, a.useNamespaceResourceScopeFormat)
+	checkAccessBodies, err := prepareCheckAccessRequestBody(request, a.clusterType, a.azureResourceId, a.useNamespaceResourceScopeFormat)
 	if err != nil {
 		return nil, errors.Wrap(err, "error in preparing check access request")
 	}

--- a/server/authzhandler.go
+++ b/server/authzhandler.go
@@ -22,7 +22,6 @@ import (
 
 	"go.kubeguard.dev/guard/authz"
 	"go.kubeguard.dev/guard/authz/providers/azure"
-	azureutils "go.kubeguard.dev/guard/util/azure"
 	errutils "go.kubeguard.dev/guard/util/error"
 
 	"github.com/pkg/errors"
@@ -34,7 +33,6 @@ type Authzhandler struct {
 	AuthRecommendedOptions  *AuthRecommendedOptions
 	AuthzRecommendedOptions *AuthzRecommendedOptions
 	Store                   authz.Store
-	operationsMap           azureutils.OperationsMap
 }
 
 func (s *Authzhandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -75,7 +73,7 @@ func (s *Authzhandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (s *Authzhandler) getAuthzProviderClient(org string) (authz.Interface, error) {
 	switch strings.ToLower(org) {
 	case azure.OrgType:
-		return azure.New(s.AuthzRecommendedOptions.Azure, s.AuthRecommendedOptions.Azure, s.operationsMap)
+		return azure.New(s.AuthzRecommendedOptions.Azure, s.AuthRecommendedOptions.Azure)
 	}
 
 	return nil, errors.Errorf("Client is using unknown organization %s", org)

--- a/server/server.go
+++ b/server/server.go
@@ -17,12 +17,14 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"go.kubeguard.dev/guard/auth/providers/token"
@@ -179,7 +181,7 @@ func (s Server) ListenAndServe() {
 
 	m.Get("/readyz", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if len(s.AuthzRecommendedOptions.AuthzProvider.Providers) > 0 && s.AuthzRecommendedOptions.AuthzProvider.Has(azure.OrgType) && s.AuthzRecommendedOptions.Azure.DiscoverResources {
-			if authzhandler.operationsMap != nil && len(authzhandler.operationsMap) > 0 {
+			if azureutils.GlobalOperationsMap != nil && len(azureutils.GlobalOperationsMap) > 0 {
 				w.WriteHeader(200)
 			} else {
 				w.WriteHeader(http.StatusInternalServerError)
@@ -228,21 +230,27 @@ func (s Server) ListenAndServe() {
 					klog.Fatalf("Authzmode %s is not supported for fetching list of resources", s.AuthzRecommendedOptions.Azure.AuthzMode)
 				}
 
-				settings, err := azureutils.NewDiscoverResourcesSettings(clusterType, s.AuthRecommendedOptions.Azure.Environment, s.AuthzRecommendedOptions.Azure.AKSAuthzTokenURL, s.AuthzRecommendedOptions.Azure.KubeConfigFile, s.AuthRecommendedOptions.Azure.TenantID, s.AuthRecommendedOptions.Azure.ClientID, s.AuthRecommendedOptions.Azure.ClientSecret)
+				err := azureutils.SetDiscoverResourcesSettings(clusterType, s.AuthRecommendedOptions.Azure.Environment, s.AuthzRecommendedOptions.Azure.AKSAuthzTokenURL, s.AuthzRecommendedOptions.Azure.KubeConfigFile, s.AuthRecommendedOptions.Azure.TenantID, s.AuthRecommendedOptions.Azure.ClientID, s.AuthRecommendedOptions.Azure.ClientSecret)
 				if err != nil {
 					klog.Fatalf("Failed to create settings for discovering resources. Error:%s", err)
 				}
 
 				discoverResourcesListStart := time.Now()
-				operationsMap, err := azureutils.DiscoverResources(settings)
+				err = azureutils.DiscoverResources()
 				discoverResourcesDuration := time.Since(discoverResourcesListStart).Seconds()
 				if err != nil {
 					azureutils.DiscoverResourcesTotalDuration.Observe(discoverResourcesDuration)
-					klog.Fatalf("Failed to create map of data actions. Error:%s", err)
+					klog.Fatalf("Failed to create map of data actions on startup. Error:%s", err)
 				}
-
 				azureutils.DiscoverResourcesTotalDuration.Observe(discoverResourcesDuration)
-				authzhandler.operationsMap = operationsMap
+
+				// start thread for reconciling the GlobalOperationsMap
+				var wg sync.WaitGroup
+				wg.Add(1)
+				go azureutils.ReconcileDiscoverResources(context.Background(), &wg, s.AuthzRecommendedOptions.Azure.ReconcileDiscoverResourcesFrequency)
+				go func() {
+					wg.Wait()
+				}()
 			}
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -181,7 +181,7 @@ func (s Server) ListenAndServe() {
 
 	m.Get("/readyz", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if len(s.AuthzRecommendedOptions.AuthzProvider.Providers) > 0 && s.AuthzRecommendedOptions.AuthzProvider.Has(azure.OrgType) && s.AuthzRecommendedOptions.Azure.DiscoverResources {
-			storedOperationsMap := azureutils.GetOperationsMap()
+			storedOperationsMap := azureutils.DeepCopyOperationsMap()
 			if len(storedOperationsMap) > 0 {
 				w.WriteHeader(200)
 			} else {

--- a/server/server.go
+++ b/server/server.go
@@ -181,7 +181,8 @@ func (s Server) ListenAndServe() {
 
 	m.Get("/readyz", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if len(s.AuthzRecommendedOptions.AuthzProvider.Providers) > 0 && s.AuthzRecommendedOptions.AuthzProvider.Has(azure.OrgType) && s.AuthzRecommendedOptions.Azure.DiscoverResources {
-			if azureutils.GlobalOperationsMap != nil && len(azureutils.GlobalOperationsMap) > 0 {
+			storedOperationsMap := azureutils.GetOperationsMap()
+			if len(storedOperationsMap) > 0 {
 				w.WriteHeader(200)
 			} else {
 				w.WriteHeader(http.StatusInternalServerError)

--- a/util/azure/utils.go
+++ b/util/azure/utils.go
@@ -259,10 +259,10 @@ func ReconcileDiscoverResources(ctx context.Context, wg *sync.WaitGroup, loopDur
 				counterDiscoverResources.WithLabelValues(ConvertIntToString(code)).Inc()
 				DiscoverResourcesTotalDuration.Observe(discoverResourcesDuration)
 				klog.Errorf("Failed to reconcile map of data actions. Error:%s", err)
+			} else {
+				counterDiscoverResources.WithLabelValues(ConvertIntToString(http.StatusOK)).Inc()
+				DiscoverResourcesTotalDuration.Observe(discoverResourcesDuration)
 			}
-
-			counterDiscoverResources.WithLabelValues(ConvertIntToString(http.StatusOK)).Inc()
-			DiscoverResourcesTotalDuration.Observe(discoverResourcesDuration)
 		case <-ctx.Done():
 			return
 		}

--- a/util/azure/utils.go
+++ b/util/azure/utils.go
@@ -299,8 +299,6 @@ func DiscoverResources() error {
 
 	createOperationsMap(apiResourcesList, operationsList)
 
-	klog.V(5).Infof("Operations Map created for resources: %s", operationsMap)
-
 	return nil
 }
 
@@ -383,6 +381,8 @@ func createOperationsMap(apiResourcesList []*metav1.APIResourceList, operationsL
 			}
 		}
 	}
+
+	klog.V(5).Infof("Operations Map created for resources: %s", operationsMap)
 }
 
 func fetchApiResources() ([]*metav1.APIResourceList, error) {

--- a/util/azure/utils_test.go
+++ b/util/azure/utils_test.go
@@ -335,12 +335,11 @@ func Test_createOperationsMap(t *testing.T) {
 		operationsMap = NewOperationsMap()
 		_ = SetDiscoverResourcesSettings(tt.args.clusterType, "", "", "", "", "", "")
 		createOperationsMap(tt.args.apiResourcesList, tt.args.operationsList)
-		got := GetOperationsMap()
-		if len(got) != len(tt.want) {
-			t.Errorf("[createOperationsMap()]Map lengths are not equal. = %v, want %v", got, tt.want)
+		if len(operationsMap) != len(tt.want) {
+			t.Errorf("[createOperationsMap()]Map lengths are not equal. = %v, want %v", operationsMap, tt.want)
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("createOperationsMap() = %v, want %v", got, tt.want)
+		if !reflect.DeepEqual(operationsMap, tt.want) {
+			t.Errorf("createOperationsMap() = %v, want %v", operationsMap, tt.want)
 		}
 	}
 }

--- a/util/azure/utils_test.go
+++ b/util/azure/utils_test.go
@@ -332,12 +332,14 @@ func Test_createOperationsMap(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		got := createOperationsMap(tt.args.apiResourcesList, tt.args.operationsList, tt.args.clusterType)
-		if len(got) != len(tt.want) {
-			t.Errorf("[createOperationsMap()]Map lengths are not equal. = %v, want %v", got, tt.want)
+		GlobalOperationsMap = NewOperationsMap()
+		_ = SetDiscoverResourcesSettings(tt.args.clusterType, "", "", "", "", "", "")
+		createOperationsMap(tt.args.apiResourcesList, tt.args.operationsList)
+		if len(GlobalOperationsMap) != len(tt.want) {
+			t.Errorf("[createOperationsMap()]Map lengths are not equal. = %v, want %v", GlobalOperationsMap, tt.want)
 		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("createOperationsMap() = %v, want %v", got, tt.want)
+		if !reflect.DeepEqual(GlobalOperationsMap, tt.want) {
+			t.Errorf("createOperationsMap() = %v, want %v", GlobalOperationsMap, tt.want)
 		}
 	}
 }

--- a/util/azure/utils_test.go
+++ b/util/azure/utils_test.go
@@ -27,6 +27,7 @@ import (
 func Test_createOperationsMap(t *testing.T) {
 	type args struct {
 		apiResourcesList []*metav1.APIResourceList
+		initializeNewMap bool
 		operationsList   []Operation
 		clusterType      string
 	}
@@ -54,6 +55,99 @@ func Test_createOperationsMap(t *testing.T) {
 						},
 					},
 				},
+				initializeNewMap: true,
+				operationsList: []Operation{
+					{
+						Name:         "Microsoft.Kubernetes/connectedClusters/apps/deployments/delete",
+						Display:      Display{Provider: "Microsoft.Kubernetes", Resource: "deployments", Operation: "some desc", Description: "some desc"},
+						IsDataAction: pointer.Bool(true),
+					},
+					{
+						Name:         "Microsoft.Kubernetes/connectedClusters/apps/deployments/read",
+						Display:      Display{Provider: "Microsoft.Kubernetes", Resource: "deployments", Operation: "some desc", Description: "some desc"},
+						IsDataAction: pointer.Bool(true),
+					},
+					{
+						Name:         "Microsoft.Kubernetes/connectedClusters/apps/deployments/write",
+						Display:      Display{Provider: "Microsoft.Kubernetes", Resource: "deployments", Operation: "some desc", Description: "some desc"},
+						IsDataAction: pointer.Bool(true),
+					},
+					{
+						Name:         "Microsoft.Kubernetes/connectedClusters/nodes/delete",
+						Display:      Display{Provider: "Microsoft.Kubernetes", Resource: "nodes", Operation: "some desc", Description: "some desc"},
+						IsDataAction: pointer.Bool(true),
+					},
+					{
+						Name:         "Microsoft.Kubernetes/connectedClusters/nodes/read",
+						Display:      Display{Provider: "Microsoft.Kubernetes", Resource: "nodes", Operation: "some desc", Description: "some desc"},
+						IsDataAction: pointer.Bool(true),
+					},
+
+					{
+						Name:         "Microsoft.Kubernetes/connectedClusters/nodes/write",
+						Display:      Display{Provider: "Microsoft.Kubernetes", Resource: "nodes", Operation: "some desc", Description: "some desc"},
+						IsDataAction: pointer.Bool(true),
+					},
+					{
+						Name:         "Microsoft.Kubernetes/connectedClusters/pods/delete",
+						Display:      Display{Provider: "Microsoft.Kubernetes", Resource: "pods", Operation: "some desc", Description: "some desc"},
+						IsDataAction: pointer.Bool(true),
+					},
+					{
+						Name:         "Microsoft.Kubernetes/connectedClusters/pods/exec/action",
+						Display:      Display{Provider: "Microsoft.Kubernetes", Resource: "pods", Operation: "some desc", Description: "some desc"},
+						IsDataAction: pointer.Bool(true),
+					},
+					{
+						Name:         "Microsoft.Kubernetes/connectedClusters/pods/read",
+						Display:      Display{Provider: "Microsoft.Kubernetes", Resource: "pods", Operation: "some desc", Description: "some desc"},
+						IsDataAction: pointer.Bool(true),
+					},
+					{
+						Name:         "Microsoft.Kubernetes/connectedClusters/pods/write",
+						Display:      Display{Provider: "Microsoft.Kubernetes", Resource: "pods", Operation: "some desc", Description: "some desc"},
+						IsDataAction: pointer.Bool(true),
+					},
+				},
+				clusterType: "Microsoft.Kubernetes/connectedClusters",
+			},
+			OperationsMap{
+				"apps": ResourceAndVerbMap{
+					"deployments": VerbAndActionsMap{
+						"read":   DataAction{ActionInfo: AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "Microsoft.Kubernetes/connectedClusters/apps/deployments/read"}, IsDataAction: true}, IsNamespacedResource: true},
+						"write":  DataAction{ActionInfo: AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "Microsoft.Kubernetes/connectedClusters/apps/deployments/write"}, IsDataAction: true}, IsNamespacedResource: true},
+						"delete": DataAction{ActionInfo: AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "Microsoft.Kubernetes/connectedClusters/apps/deployments/delete"}, IsDataAction: true}, IsNamespacedResource: true},
+					},
+				},
+				"v1": ResourceAndVerbMap{
+					"nodes": VerbAndActionsMap{
+						"read":   DataAction{ActionInfo: AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "Microsoft.Kubernetes/connectedClusters/nodes/read"}, IsDataAction: true}, IsNamespacedResource: false},
+						"write":  DataAction{ActionInfo: AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "Microsoft.Kubernetes/connectedClusters/nodes/write"}, IsDataAction: true}, IsNamespacedResource: false},
+						"delete": DataAction{ActionInfo: AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "Microsoft.Kubernetes/connectedClusters/nodes/delete"}, IsDataAction: true}, IsNamespacedResource: false},
+					},
+					"pods": VerbAndActionsMap{
+						"read":        DataAction{ActionInfo: AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "Microsoft.Kubernetes/connectedClusters/pods/read"}, IsDataAction: true}, IsNamespacedResource: true},
+						"write":       DataAction{ActionInfo: AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "Microsoft.Kubernetes/connectedClusters/pods/write"}, IsDataAction: true}, IsNamespacedResource: true},
+						"delete":      DataAction{ActionInfo: AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "Microsoft.Kubernetes/connectedClusters/pods/delete"}, IsDataAction: true}, IsNamespacedResource: true},
+						"exec/action": DataAction{ActionInfo: AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "Microsoft.Kubernetes/connectedClusters/pods/exec/action"}, IsDataAction: true}, IsNamespacedResource: true},
+					},
+				},
+			},
+		},
+
+		{
+			"if existing map is present, create operations map should not remove existing elements",
+			args{
+				apiResourcesList: []*metav1.APIResourceList{
+					{
+						GroupVersion: "v1",
+						APIResources: []metav1.APIResource{
+							{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"}},
+							{Name: "nodes", Namespaced: false, Kind: "Node", Verbs: []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"}},
+						},
+					},
+				},
+				initializeNewMap: false,
 				operationsList: []Operation{
 					{
 						Name:         "Microsoft.Kubernetes/connectedClusters/apps/deployments/delete",
@@ -150,6 +244,7 @@ func Test_createOperationsMap(t *testing.T) {
 						},
 					},
 				},
+				initializeNewMap: true,
 				operationsList: []Operation{
 					{
 						Name:         "Microsoft.Kubernetes/connectedClusters/pods/delete",
@@ -204,6 +299,7 @@ func Test_createOperationsMap(t *testing.T) {
 						},
 					},
 				},
+				initializeNewMap: true,
 				operationsList: []Operation{
 					{
 						Name:         "Microsoft.Kubernetes/connectedClusters/apps/deployments/delete",
@@ -279,6 +375,7 @@ func Test_createOperationsMap(t *testing.T) {
 						},
 					},
 				},
+				initializeNewMap: true,
 				operationsList: []Operation{
 					{
 						Name:         "Microsoft.Kubernetes/connectedClusters/events/delete",
@@ -332,7 +429,9 @@ func Test_createOperationsMap(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		operationsMap = NewOperationsMap()
+		if tt.args.initializeNewMap {
+			operationsMap = NewOperationsMap()
+		}
 		_ = SetDiscoverResourcesSettings(tt.args.clusterType, "", "", "", "", "", "")
 		createOperationsMap(tt.args.apiResourcesList, tt.args.operationsList)
 		if len(operationsMap) != len(tt.want) {

--- a/util/azure/utils_test.go
+++ b/util/azure/utils_test.go
@@ -332,14 +332,15 @@ func Test_createOperationsMap(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		GlobalOperationsMap = NewOperationsMap()
+		operationsMap = NewOperationsMap()
 		_ = SetDiscoverResourcesSettings(tt.args.clusterType, "", "", "", "", "", "")
 		createOperationsMap(tt.args.apiResourcesList, tt.args.operationsList)
-		if len(GlobalOperationsMap) != len(tt.want) {
-			t.Errorf("[createOperationsMap()]Map lengths are not equal. = %v, want %v", GlobalOperationsMap, tt.want)
+		got := GetOperationsMap()
+		if len(got) != len(tt.want) {
+			t.Errorf("[createOperationsMap()]Map lengths are not equal. = %v, want %v", got, tt.want)
 		}
-		if !reflect.DeepEqual(GlobalOperationsMap, tt.want) {
-			t.Errorf("createOperationsMap() = %v, want %v", GlobalOperationsMap, tt.want)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("createOperationsMap() = %v, want %v", got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
Discovering resources will be a best effort scenario. We may face errors while fetching the apiresources from apiserver as some apiservices may not be available. Also during upgrades,guard might call the old apiserver for the list. 

Added a reconciler which will updated the map every 5m. The frequency can be configured via flag.
It will not remove existing elements , only new elements will be added.
