### PR TITLE
Support for ARC obo service for getMemberGroups

### DIFF
--- a/auth/providers/azure/azure.go
+++ b/auth/providers/azure/azure.go
@@ -106,7 +106,7 @@ func New(ctx context.Context, opts Options) (auth.Interface, error) {
 	case ClientCredentialAuthMode:
 		c.graphClient, err = graph.New(c.ClientID, c.ClientSecret, c.TenantID, c.UseGroupUID, authInfoVal.AADEndpoint, authInfoVal.MSGraphHost)
 	case ARCAuthMode:
-		c.graphClient, err = graph.NewWithARC(c.MSIAudience)
+		c.graphClient, err = graph.NewWithARC(c.MSIAudience, c.ResourceId)
 	case OBOAuthMode:
 		c.graphClient, err = graph.NewWithOBO(c.ClientID, c.ClientSecret, c.TenantID, authInfoVal.AADEndpoint, authInfoVal.MSGraphHost)
 	case AKSAuthMode:

--- a/auth/providers/azure/azure.go
+++ b/auth/providers/azure/azure.go
@@ -74,10 +74,9 @@ type Authenticator struct {
 }
 
 type authInfo struct {
-	AADEndpoint         string
-	ResourceMgrEndpoint string
-	MSGraphHost         string
-	Issuer              string
+	AADEndpoint string
+	MSGraphHost string
+	Issuer      string
 }
 
 func New(ctx context.Context, opts Options) (auth.Interface, error) {
@@ -389,9 +388,8 @@ func getAuthInfo(ctx context.Context, environment, tenantID string, getMetadata 
 	}
 
 	return &authInfo{
-		AADEndpoint:         env.ActiveDirectoryEndpoint,
-		ResourceMgrEndpoint: env.ResourceManagerEndpoint,
-		MSGraphHost:         msgraphHost,
-		Issuer:              metadata.Issuer,
+		AADEndpoint: env.ActiveDirectoryEndpoint,
+		MSGraphHost: msgraphHost,
+		Issuer:      metadata.Issuer,
 	}, nil
 }

--- a/auth/providers/azure/azure.go
+++ b/auth/providers/azure/azure.go
@@ -230,7 +230,7 @@ func (s Authenticator) Check(ctx context.Context, token string) (*authv1.UserInf
 			return nil, err
 		}
 		if s.Options.AuthMode == ARCAuthMode {
-			resp.Groups, err = s.graphClient.GetMemberGroupsUsingARCOboService(ctx, s.Options.TenantID, s.Options.ResourceId, token)
+			resp.Groups, err = s.graphClient.GetMemberGroupsUsingARCOboService(ctx, s.Options.TenantID, s.Options.ResourceId, s.Options.AzureRegion, token)
 		} else {
 			resp.Groups, err = s.graphClient.GetGroups(ctx, resp.Username)
 		}

--- a/auth/providers/azure/azure.go
+++ b/auth/providers/azure/azure.go
@@ -106,7 +106,7 @@ func New(ctx context.Context, opts Options) (auth.Interface, error) {
 	case ClientCredentialAuthMode:
 		c.graphClient, err = graph.New(c.ClientID, c.ClientSecret, c.TenantID, c.UseGroupUID, authInfoVal.AADEndpoint, authInfoVal.MSGraphHost)
 	case ARCAuthMode:
-		c.graphClient, err = graph.NewWithARC(c.MSIAudience, c.ResourceId)
+		c.graphClient, err = graph.NewWithARC(c.MSIAudience)
 	case OBOAuthMode:
 		c.graphClient, err = graph.NewWithOBO(c.ClientID, c.ClientSecret, c.TenantID, authInfoVal.AADEndpoint, authInfoVal.MSGraphHost)
 	case AKSAuthMode:

--- a/auth/providers/azure/azure.go
+++ b/auth/providers/azure/azure.go
@@ -106,7 +106,7 @@ func New(ctx context.Context, opts Options) (auth.Interface, error) {
 	case ClientCredentialAuthMode:
 		c.graphClient, err = graph.New(c.ClientID, c.ClientSecret, c.TenantID, c.UseGroupUID, authInfoVal.AADEndpoint, authInfoVal.MSGraphHost)
 	case ARCAuthMode:
-		c.graphClient, err = graph.NewWithARC(c.MSIAudience)
+		c.graphClient, err = graph.NewWithARC(c.ClientID, c.ResourceId, c.TenantID, c.AzureRegion)
 	case OBOAuthMode:
 		c.graphClient, err = graph.NewWithOBO(c.ClientID, c.ClientSecret, c.TenantID, authInfoVal.AADEndpoint, authInfoVal.MSGraphHost)
 	case AKSAuthMode:
@@ -229,12 +229,7 @@ func (s Authenticator) Check(ctx context.Context, token string) (*authv1.UserInf
 		if err := s.graphClient.RefreshToken(ctx, token); err != nil {
 			return nil, err
 		}
-		if s.Options.AuthMode == ARCAuthMode {
-			resp.Groups, err = s.graphClient.GetMemberGroupsUsingARCOboService(ctx, s.Options.TenantID, s.Options.ResourceId, s.Options.AzureRegion, token)
-		} else {
-			resp.Groups, err = s.graphClient.GetGroups(ctx, resp.Username)
-		}
-
+		resp.Groups, err = s.graphClient.GetGroups(ctx, resp.Username, token)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get groups")
 		}

--- a/auth/providers/azure/azure_test.go
+++ b/auth/providers/azure/azure_test.go
@@ -100,7 +100,7 @@ func newRSAKey() (*signingKey, error) {
 	return &signingKey{"", priv, priv.Public(), jose.RS256}, nil
 }
 
-func clientSetup(clientID, clientSecret, tenantID, serverUrl string, useGroupUID, verifyClientID bool) (*Authenticator, error) {
+func clientSetup(clientID, clientSecret, tenantID, serverUrl string, useGroupUID, verifyClientID bool, authMode string) (*Authenticator, error) {
 	c := &Authenticator{
 		Options: Options{
 			Environment:    "",
@@ -146,6 +146,15 @@ func serverSetup(loginResp string, loginStatus int, jwkResp, groupIds, groupList
 	m.Post("/login", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(loginStatus)
 		_, _ = w.Write([]byte(loginResp))
+	}))
+
+	m.Post("/obo/resourceid/getMemberGroups", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(groupStatus) > 0 {
+			w.WriteHeader(groupStatus[0])
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		_, _ = w.Write(groupIds)
 	}))
 
 	m.Post("/api/users/nahid/getMemberGroups", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -262,7 +271,7 @@ func assertUserInfo(t *testing.T, info *authv1.UserInfo, groupSize int, useGroup
 	}
 }
 
-func getServerAndClient(t *testing.T, signKey *signingKey, loginResp string, groupSize int, useGroupUID, verifyClientID bool, groupStatus ...int) (*httptest.Server, *Authenticator) {
+func getServerAndClient(t *testing.T, signKey *signingKey, loginResp string, groupSize int, useGroupUID, verifyClientID bool, authMode string, groupStatus ...int) (*httptest.Server, *Authenticator) {
 	jwkSet := signKey.jwk()
 	jwkResp, err := jsonLib.Marshal(jwkSet)
 	if err != nil {
@@ -277,7 +286,7 @@ func getServerAndClient(t *testing.T, signKey *signingKey, loginResp string, gro
 		t.Fatalf("Error when creating server, reason: %v", err)
 	}
 
-	client, err := clientSetup("client_id", "client_secret", "tenant_id", srv.URL, useGroupUID, verifyClientID)
+	client, err := clientSetup("client_id", "client_secret", "tenant_id", srv.URL, useGroupUID, verifyClientID, authMode)
 	if err != nil {
 		t.Fatalf("Error when creatidng azure client. reason : %v", err)
 	}
@@ -312,7 +321,7 @@ func TestCheckAzureAuthenticationSuccess(t *testing.T) {
 	for _, test := range dataset {
 		// authenticated : true
 		t.Run(fmt.Sprintf("authentication successful, group size %v", test.groupSize), func(t *testing.T) {
-			srv, client := getServerAndClient(t, signKey, loginResp, test.groupSize, false, false)
+			srv, client := getServerAndClient(t, signKey, loginResp, test.groupSize, false, false, ClientCredentialAuthMode)
 			defer srv.Close()
 
 			token, err := signKey.sign([]byte(fmt.Sprintf(test.token, srv.URL)))
@@ -329,7 +338,7 @@ func TestCheckAzureAuthenticationSuccess(t *testing.T) {
 	for _, test := range dataset {
 		// authenticated : true
 		t.Run(fmt.Sprintf("authentication (with group IDs) successful, group size %v", test.groupSize), func(t *testing.T) {
-			srv, client := getServerAndClient(t, signKey, loginResp, test.groupSize, true, false)
+			srv, client := getServerAndClient(t, signKey, loginResp, test.groupSize, true, false, ClientCredentialAuthMode)
 			defer srv.Close()
 
 			token, err := signKey.sign([]byte(fmt.Sprintf(test.token, srv.URL)))
@@ -365,7 +374,23 @@ func TestCheckAzureAuthenticationWithOverageCheckOption(t *testing.T) {
 	for _, verifyClientID := range verifyClientIDs {
 		for _, test := range datasetForSuccess {
 			t.Run(fmt.Sprintf("authentication successful, verifyClientID: %t, group size %v", verifyClientID, test.groupSize), func(t *testing.T) {
-				srv, client := getServerAndClient(t, signKey, loginResp, test.groupSize, true, verifyClientID)
+				srv, client := getServerAndClient(t, signKey, loginResp, test.groupSize, true, verifyClientID, ClientCredentialAuthMode)
+				client.Options.ResolveGroupMembershipOnlyOnOverageClaim = true
+				client.Options.UseGroupUID = true
+				defer srv.Close()
+
+				token, err := signKey.sign([]byte(fmt.Sprintf(test.token, srv.URL)))
+				if err != nil {
+					t.Fatalf("Error when signing token. reason: %v", err)
+				}
+
+				resp, err := client.Check(ctx, token)
+				assert.Nil(t, err)
+				assertUserInfo(t, resp, test.groupSize, client.UseGroupUID)
+			})
+
+			t.Run(fmt.Sprintf("authentication successful, authmode: %s, group size %v", ARCAuthMode, test.groupSize), func(t *testing.T) {
+				srv, client := getServerAndClient(t, signKey, loginResp, test.groupSize, true, verifyClientID, ARCAuthMode)
 				client.Options.ResolveGroupMembershipOnlyOnOverageClaim = true
 				client.Options.UseGroupUID = true
 				defer srv.Close()
@@ -420,7 +445,27 @@ func TestCheckAzureAuthenticationFailed(t *testing.T) {
 	for _, test := range dataset {
 		t.Run(test.testName, func(t *testing.T) {
 			t.Log(test)
-			srv, client := getServerAndClient(t, signKey, loginResp, 5, false, false, test.groupRespStatus...)
+			srv, client := getServerAndClient(t, signKey, loginResp, 5, false, false, ClientCredentialAuthMode, test.groupRespStatus...)
+			defer srv.Close()
+
+			var token string
+			if test.token != badToken {
+				token, err = signKey.sign([]byte(fmt.Sprintf(test.token, srv.URL)))
+				if err != nil {
+					t.Fatalf("Error when signing token. reason: %v", err)
+				}
+			} else {
+				token = test.token
+			}
+
+			resp, err := client.Check(ctx, token)
+			assert.NotNil(t, err)
+			assert.Nil(t, resp)
+		})
+
+		t.Run(test.testName, func(t *testing.T) {
+			t.Log(test)
+			srv, client := getServerAndClient(t, signKey, loginResp, 5, false, false, ARCAuthMode, test.groupRespStatus...)
 			defer srv.Close()
 
 			var token string

--- a/auth/providers/azure/azure_test.go
+++ b/auth/providers/azure/azure_test.go
@@ -111,6 +111,7 @@ func clientSetup(clientID, clientSecret, tenantID, serverUrl string, useGroupUID
 			AuthMode:       ClientCredentialAuthMode,
 			AKSTokenURL:    "",
 			VerifyClientID: verifyClientID,
+			AzureRegion:    "eastus",
 		},
 	}
 

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -165,11 +165,13 @@ func (u *UserInfo) GetMemberGroupsUsingARCOboService(ctx context.Context, tenant
 	if err := json.NewEncoder(buf).Encode(reqBody); err != nil {
 		return nil, errors.Wrap(err, "failed to encode token request")
 	}
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("https://eus.obo.arc.azure.com/%s/%s", resourceID, "getMemberGroups"), buf)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("https://eus.obo.arc.azure.com:8084%s/%s", resourceID, "getMemberGroups"), buf)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create getMemberGroups request")
 	}
-	req.Header.Set("Content-Type", "application/json")
+	// Set the auth headers
+	req.Header = u.headers
+
 	correlationID := uuid.New()
 	req.Header.Set("x-ms-correlation-request-id", correlationID.String())
 	resp, err := u.client.Do(req.WithContext(ctx))
@@ -312,9 +314,9 @@ func NewWithAKS(tokenURL, tenantID, msgraphHost string) (*UserInfo, error) {
 }
 
 // NewWithARC returns a new UserInfo object used in ARC
-func NewWithARC(msiAudience string) (*UserInfo, error) {
+func NewWithARC(msiAudience string, armID string) (*UserInfo, error) {
 	graphURL, _ := url.Parse("")
-	tokenProvider := NewMSITokenProvider(msiAudience, MSIEndpointForARC)
+	tokenProvider := NewMSITokenProvider(msiAudience, MSIEndpointForARC, armID)
 
 	return newUserInfo(tokenProvider, graphURL, false)
 }

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -187,7 +187,7 @@ func (u *UserInfo) getMemberGroupsUsingARCOboService(ctx context.Context, access
 
 	// the arc obo service does not support getting groups for applications
 	if claims[idtypClaim] != nil {
-		return nil, errors.New("Obo.GetMemberGroups call is not supported for applications.")
+		return nil, errors.New("Overage claim (users with more than 200 group membership) for SPN is currently not supported. For troubleshooting, please refer to aka.ms/overageclaimtroubleshoot")
 	}
 
 	buf := new(bytes.Buffer)
@@ -249,6 +249,9 @@ func (u *UserInfo) getMemberGroupsUsingARCOboService(ctx context.Context, access
 	for i := 0; i < len(groupResponse.Value); i++ {
 		groupIDs = append(groupIDs, groupResponse.Value[i])
 	}
+
+	totalGroups := len(groupIDs)
+	klog.V(10).Infof("No of groups returned by OBO service: %d", totalGroups)
 
 	return groupIDs, nil
 }
@@ -401,7 +404,7 @@ func NewWithAKS(tokenURL, tenantID, msgraphHost string) (*UserInfo, error) {
 }
 
 // NewWithARC returns a new UserInfo object used in ARC
-func NewWithARC(msiAudience string, resourceId string, tenantId string, region string) (*UserInfo, error) {
+func NewWithARC(msiAudience, resourceId, tenantId, region string) (*UserInfo, error) {
 	graphURL, _ := url.Parse("")
 	tokenProvider := NewMSITokenProvider(msiAudience, MSIEndpointForARC)
 

--- a/auth/providers/azure/graph/graph_test.go
+++ b/auth/providers/azure/graph/graph_test.go
@@ -403,8 +403,8 @@ func TestGetMemberGroupsUsingARCOboService(t *testing.T) {
 			t.Error("Group list should be nil")
 		}
 
-		if !strings.Contains(err.Error(), "Obo.GetMemberGroups call is not supported for applications.") {
-			t.Errorf("Expected: Obo.GetMemberGroups call is not supported for applications., Got: %s", err.Error())
+		if !strings.Contains(err.Error(), "Overage claim (users with more than 200 group membership) for SPN is currently not supported. For troubleshooting, please refer to aka.ms/overageclaimtroubleshoot") {
+			t.Errorf("Expected: Overage claim (users with more than 200 group membership) for SPN is currently not supported. For troubleshooting, please refer to aka.ms/overageclaimtroubleshoot, Got: %s", err.Error())
 		}
 	})
 	t.Run("bad response body", func(t *testing.T) {

--- a/auth/providers/azure/graph/graph_test.go
+++ b/auth/providers/azure/graph/graph_test.go
@@ -37,6 +37,7 @@ const (
 	accessTokenWithOverageClaim       = `{ "aud": "client", "iss" : "%v", "exp" : "%v",  "upn": "arc", "_claim_names": {"groups": "src1"}, "_claim_sources": {"src1": {"endpoint": "https://foobar" }} }`
 	accessTokenWithOverageClaimForApp = `{ "aud": "client", "iss" : "%v", "exp" : "%v", "idtyp" : "app", "upn": "arc", "_claim_names": {"groups": "src1"}, "_claim_sources": {"src1": {"endpoint": "https://foobar" }} }`
 	location                          = "eastus"
+	tenant_id                         = "tenantId"
 )
 
 type swKey struct {
@@ -320,6 +321,10 @@ func TestGetMemberGroupsUsingARCOboService(t *testing.T) {
 		  }`
 
 		ts, u := getAPIServerAndUserInfo(http.StatusOK, validBody)
+		u.region = location
+		u.authMode = arcAuthMode
+		u.resourceID = ts.URL
+		u.tenantID = tenant_id
 		defer ts.Close()
 
 		getOBORegionalEndpoint = func(location string, resourceID string) (string, error) {
@@ -333,7 +338,7 @@ func TestGetMemberGroupsUsingARCOboService(t *testing.T) {
 			t.Fatalf("Error when generating token. Error:%+v", err)
 		}
 
-		groups, err := u.GetMemberGroupsUsingARCOboService(ctx, "tenantId", ts.URL, location, tokenstring)
+		groups, err := u.getMemberGroupsUsingARCOboService(ctx, tokenstring)
 		if err != nil {
 			t.Errorf("Should not have gotten error: %s", err)
 		}
@@ -343,6 +348,10 @@ func TestGetMemberGroupsUsingARCOboService(t *testing.T) {
 	})
 	t.Run("bad server response", func(t *testing.T) {
 		ts, u := getAPIServerAndUserInfo(http.StatusInternalServerError, "shutdown")
+		u.region = location
+		u.authMode = arcAuthMode
+		u.resourceID = ts.URL
+		u.tenantID = tenant_id
 		defer ts.Close()
 
 		getOBORegionalEndpoint = func(location string, resourceID string) (string, error) {
@@ -356,7 +365,7 @@ func TestGetMemberGroupsUsingARCOboService(t *testing.T) {
 			t.Fatalf("Error when generating token. Error:%+v", err)
 		}
 
-		groups, err := u.GetMemberGroupsUsingARCOboService(ctx, "tenantId", ts.URL, location, tokenstring)
+		groups, err := u.getMemberGroupsUsingARCOboService(ctx, tokenstring)
 		if err == nil {
 			t.Error("Should have gotten error")
 		}
@@ -370,6 +379,10 @@ func TestGetMemberGroupsUsingARCOboService(t *testing.T) {
 	})
 	t.Run("applications not supported error", func(t *testing.T) {
 		ts, u := getAPIServerAndUserInfo(http.StatusBadRequest, "")
+		u.region = location
+		u.authMode = arcAuthMode
+		u.resourceID = ts.URL
+		u.tenantID = tenant_id
 		defer ts.Close()
 		getOBORegionalEndpoint = func(location string, resourceID string) (string, error) {
 			return ts.URL, nil
@@ -382,7 +395,7 @@ func TestGetMemberGroupsUsingARCOboService(t *testing.T) {
 			t.Fatalf("Error when generating token. Error:%+v", err)
 		}
 
-		groups, err := u.GetMemberGroupsUsingARCOboService(ctx, "tenantId", ts.URL, location, tokenstring)
+		groups, err := u.getMemberGroupsUsingARCOboService(ctx, tokenstring)
 		if err == nil {
 			t.Error("Should have gotten error")
 		}
@@ -396,6 +409,10 @@ func TestGetMemberGroupsUsingARCOboService(t *testing.T) {
 	})
 	t.Run("bad response body", func(t *testing.T) {
 		ts, u := getAPIServerAndUserInfo(http.StatusOK, "{bad_json")
+		u.region = location
+		u.authMode = arcAuthMode
+		u.resourceID = ts.URL
+		u.tenantID = tenant_id
 		defer ts.Close()
 
 		getOBORegionalEndpoint = func(location string, resourceID string) (string, error) {
@@ -409,7 +426,7 @@ func TestGetMemberGroupsUsingARCOboService(t *testing.T) {
 			t.Fatalf("Error when generating token. Error:%+v", err)
 		}
 
-		groups, err := u.GetMemberGroupsUsingARCOboService(ctx, "tenantId", ts.URL, location, tokenstring)
+		groups, err := u.getMemberGroupsUsingARCOboService(ctx, tokenstring)
 		if err == nil {
 			t.Error("Should have gotten error")
 		}
@@ -465,7 +482,7 @@ func TestGetGroups(t *testing.T) {
 	}
 	defer ts.Close()
 
-	groups, err := u.GetGroups(ctx, "blackbriar@cia.gov")
+	groups, err := u.GetGroups(ctx, "blackbriar@cia.gov", "")
 	if err != nil {
 		t.Errorf("Should not have gotten error: %s", err)
 	}
@@ -483,7 +500,7 @@ func TestGetGroups(t *testing.T) {
 	}
 	defer ts.Close()
 
-	groups, err = uWithGroupID.GetGroups(ctx, "blackbriar@cia.gov")
+	groups, err = uWithGroupID.GetGroups(ctx, "blackbriar@cia.gov", "")
 	if err != nil {
 		t.Errorf("Should not have gotten error: %s", err)
 	}
@@ -559,7 +576,7 @@ func TestGetGroupsPaging(t *testing.T) {
 	defer ts.Close()
 
 	ctx := context.Background()
-	groups, err := u.GetGroups(ctx, "blackbriar@cia.gov")
+	groups, err := u.GetGroups(ctx, "blackbriar@cia.gov", "")
 	if err != nil {
 		t.Errorf("Should not have gotten error: %s", err)
 	}

--- a/auth/providers/azure/graph/msi_tokenprovider.go
+++ b/auth/providers/azure/graph/msi_tokenprovider.go
@@ -1,0 +1,106 @@
+/*
+Copyright The Guard Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package graph
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"go.kubeguard.dev/guard/util/httpclient"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	MSIEndpointForARC = "http://127.0.0.1:8421/metadata/identity/oauth2/token?api-version=2018-02-01"
+)
+
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	ExpiresIn    string `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresOn    string `json:"expires_on"`
+	NotBefore    string `json:"not_before"`
+	Resource     string `json:"resource"`
+	TokenType    string `json:"token_type"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+type msiTokenProvider struct {
+	name        string
+	client      *http.Client
+	resource    string
+	msiEndpoint string
+}
+
+// NewMSITokenProvider returns a TokenProvider that implements OAuth msi flow on Azure Active Directory
+func NewMSITokenProvider(msiAudience string, msiEndpoint string) TokenProvider {
+	return &msiTokenProvider{
+		name:        "MSITokenProvider",
+		client:      httpclient.DefaultHTTPClient,
+		resource:    msiAudience,
+		msiEndpoint: msiEndpoint,
+	}
+}
+
+func (u *msiTokenProvider) Name() string { return u.name }
+
+func (u *msiTokenProvider) Acquire(ctx context.Context, token string) (AuthResponse, error) {
+	tokenResp := &TokenResponse{}
+	authResp := AuthResponse{}
+	var msi_endpoint *url.URL
+	msi_endpoint, err := url.Parse(u.msiEndpoint)
+	if err != nil {
+		return authResp, errors.Wrap(err, "Failed to create msi request for getting token.")
+	}
+	msi_parameters := msi_endpoint.Query()
+	msi_parameters.Add("resource", u.resource)
+	msi_endpoint.RawQuery = msi_parameters.Encode()
+	req, err := http.NewRequest(http.MethodGet, msi_endpoint.String(), nil)
+	if err != nil {
+		return authResp, errors.Wrap(err, "Failed to create msi request for getting token.")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("Metadata", "true")
+	client := httpclient.DefaultHTTPClient
+	resp, err := client.Do(req)
+	if err != nil {
+		return authResp, errors.Wrap(err, "Failed to send msi request for getting token.")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		return authResp, errors.Errorf("MSI Token Request failed with status code: %d and response: %s", resp.StatusCode, string(data))
+	}
+	err = json.NewDecoder(resp.Body).Decode(&tokenResp)
+	if err != nil {
+		return authResp, errors.Wrapf(err, "Failed to decode response")
+	}
+
+	authResp.TokenType = tokenResp.TokenType
+	authResp.Expires, err = strconv.Atoi(tokenResp.ExpiresIn)
+	if err != nil {
+		return authResp, errors.Wrapf(err, "Failed to decode expiry date")
+	}
+	authResp.Token = tokenResp.AccessToken
+
+	return authResp, nil
+}

--- a/auth/providers/azure/graph/msi_tokenprovider.go
+++ b/auth/providers/azure/graph/msi_tokenprovider.go
@@ -48,17 +48,15 @@ type msiTokenProvider struct {
 	client      *http.Client
 	resource    string
 	msiEndpoint string
-	xmsmirid    string
 }
 
 // NewMSITokenProvider returns a TokenProvider that implements OAuth msi flow on Azure Active Directory
-func NewMSITokenProvider(msiAudience string, msiEndpoint string, xmsmirid string) TokenProvider {
+func NewMSITokenProvider(msiAudience string, msiEndpoint string) TokenProvider {
 	return &msiTokenProvider{
 		name:        "MSITokenProvider",
 		client:      httpclient.DefaultHTTPClient,
 		resource:    msiAudience,
 		msiEndpoint: msiEndpoint,
-		xmsmirid:    xmsmirid,
 	}
 }
 
@@ -81,9 +79,6 @@ func (u *msiTokenProvider) Acquire(ctx context.Context, token string) (AuthRespo
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("Metadata", "true")
-	if u.xmsmirid != "" {
-		req.Header.Set("xms_mirid", u.xmsmirid)
-	}
 	client := httpclient.DefaultHTTPClient
 	resp, err := client.Do(req)
 	if err != nil {

--- a/auth/providers/azure/graph/msi_tokenprovider.go
+++ b/auth/providers/azure/graph/msi_tokenprovider.go
@@ -48,15 +48,17 @@ type msiTokenProvider struct {
 	client      *http.Client
 	resource    string
 	msiEndpoint string
+	xmsmirid    string
 }
 
 // NewMSITokenProvider returns a TokenProvider that implements OAuth msi flow on Azure Active Directory
-func NewMSITokenProvider(msiAudience string, msiEndpoint string) TokenProvider {
+func NewMSITokenProvider(msiAudience string, msiEndpoint string, xmsmirid string) TokenProvider {
 	return &msiTokenProvider{
 		name:        "MSITokenProvider",
 		client:      httpclient.DefaultHTTPClient,
 		resource:    msiAudience,
 		msiEndpoint: msiEndpoint,
+		xmsmirid:    xmsmirid,
 	}
 }
 
@@ -79,6 +81,9 @@ func (u *msiTokenProvider) Acquire(ctx context.Context, token string) (AuthRespo
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("Metadata", "true")
+	if u.xmsmirid != "" {
+		req.Header.Set("xms_mirid", u.xmsmirid)
+	}
 	client := httpclient.DefaultHTTPClient
 	resp, err := client.Do(req)
 	if err != nil {

--- a/auth/providers/azure/graph/msi_tokenprovider.go
+++ b/auth/providers/azure/graph/msi_tokenprovider.go
@@ -51,7 +51,7 @@ type msiTokenProvider struct {
 }
 
 // NewMSITokenProvider returns a TokenProvider that implements OAuth msi flow on Azure Active Directory
-func NewMSITokenProvider(msiAudience string, msiEndpoint string) TokenProvider {
+func NewMSITokenProvider(msiAudience, msiEndpoint string) TokenProvider {
 	return &msiTokenProvider{
 		name:        "MSITokenProvider",
 		client:      httpclient.DefaultHTTPClient,

--- a/auth/providers/azure/graph/msi_tokenprovider_test.go
+++ b/auth/providers/azure/graph/msi_tokenprovider_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright The Guard Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package graph
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMSITokenProvider(t *testing.T) {
+	const (
+		inputAccessToken    = "inputAccessToken"
+		msiAccessToken      = "msiAccessToken"
+		tokenResponse       = `{"token_type":"Bearer","expires_in":"3599","access_token":"%s"}`
+		expectedContentType = "application/json"
+		expectedTokenType   = "Bearer"
+	)
+
+	t.Run("Upon Success Response", func(t *testing.T) {
+		s := startMSITestServer(t, func(rw http.ResponseWriter, req *http.Request) {
+			if req.Method != http.MethodGet {
+				t.Errorf("expected http method %s, actual %s", http.MethodGet, req.Method)
+			}
+			if req.Header.Get("Content-Type") != expectedContentType {
+				t.Errorf("expected content type: %s, actual: %s", expectedContentType, req.Header.Get("Content-Type"))
+			}
+			_, _ = rw.Write([]byte(fmt.Sprintf(tokenResponse, msiAccessToken)))
+		})
+
+		defer stopMSITestServer(t, s)
+
+		ctx := context.Background()
+		r := NewMSITokenProvider("http://management.azure.com", s.URL)
+		resp, err := r.Acquire(ctx, inputAccessToken)
+		if err != nil {
+			t.Fatalf("refresh should not return error: %s", err)
+		}
+
+		if resp.Token != msiAccessToken {
+			t.Errorf("returned obo token '%s' doesn't match expected '%s'", resp.Token, msiAccessToken)
+		}
+		if resp.TokenType != expectedTokenType {
+			t.Errorf("expected token type: Bearer, actual: %s", resp.TokenType)
+		}
+	})
+
+	t.Run("Upon Error Response", func(t *testing.T) {
+		s := startMSITestServer(t, func(rw http.ResponseWriter, req *http.Request) {
+			if req.Method != http.MethodGet {
+				t.Errorf("expected http method %s, actual %s", http.MethodGet, req.Method)
+			}
+			if req.Header.Get("Content-Type") != expectedContentType {
+				t.Errorf("expected content type: %s, actual: %s", expectedContentType, req.Header.Get("Content-Type"))
+			}
+
+			rw.WriteHeader(http.StatusBadRequest)
+			_, _ = rw.Write([]byte(`{"error":{"code":"Authorization_RequestDenied","message":"Insufficient privileges to complete the operation.","innerError":{"request-id":"6e73da70-96f3-4415-8c6a-a940cb1ba0e2","date":"2019-12-17T21:57:17"}}}`))
+		})
+
+		defer stopMSITestServer(t, s)
+
+		ctx := context.Background()
+		r := NewMSITokenProvider("http://management.azure.com", s.URL)
+		resp, err := r.Acquire(ctx, inputAccessToken)
+		if err == nil {
+			t.Error("refresh should return error")
+		}
+
+		if resp.Token != "" {
+			t.Errorf("returned obo token '%s' should be empty", resp.Token)
+		}
+		if resp.TokenType != "" {
+			t.Errorf("expected token type: %s should be empty", resp.TokenType)
+		}
+	})
+}
+
+func startMSITestServer(t *testing.T, handler func(rw http.ResponseWriter, req *http.Request)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(handler))
+}
+
+func stopMSITestServer(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	server.Close()
+}

--- a/auth/providers/azure/graph/msi_tokenprovider_test.go
+++ b/auth/providers/azure/graph/msi_tokenprovider_test.go
@@ -47,7 +47,7 @@ func TestMSITokenProvider(t *testing.T) {
 		defer stopMSITestServer(t, s)
 
 		ctx := context.Background()
-		r := NewMSITokenProvider("http://management.azure.com", s.URL, "")
+		r := NewMSITokenProvider("http://management.azure.com", s.URL)
 		resp, err := r.Acquire(ctx, inputAccessToken)
 		if err != nil {
 			t.Fatalf("refresh should not return error: %s", err)
@@ -77,7 +77,7 @@ func TestMSITokenProvider(t *testing.T) {
 		defer stopMSITestServer(t, s)
 
 		ctx := context.Background()
-		r := NewMSITokenProvider("http://management.azure.com", s.URL, "")
+		r := NewMSITokenProvider("http://management.azure.com", s.URL)
 		resp, err := r.Acquire(ctx, inputAccessToken)
 		if err == nil {
 			t.Error("refresh should return error")

--- a/auth/providers/azure/graph/msi_tokenprovider_test.go
+++ b/auth/providers/azure/graph/msi_tokenprovider_test.go
@@ -47,7 +47,7 @@ func TestMSITokenProvider(t *testing.T) {
 		defer stopMSITestServer(t, s)
 
 		ctx := context.Background()
-		r := NewMSITokenProvider("http://management.azure.com", s.URL)
+		r := NewMSITokenProvider("http://management.azure.com", s.URL, "")
 		resp, err := r.Acquire(ctx, inputAccessToken)
 		if err != nil {
 			t.Fatalf("refresh should not return error: %s", err)
@@ -77,7 +77,7 @@ func TestMSITokenProvider(t *testing.T) {
 		defer stopMSITestServer(t, s)
 
 		ctx := context.Background()
-		r := NewMSITokenProvider("http://management.azure.com", s.URL)
+		r := NewMSITokenProvider("http://management.azure.com", s.URL, "")
 		resp, err := r.Acquire(ctx, inputAccessToken)
 		if err == nil {
 			t.Error("refresh should return error")

--- a/auth/providers/azure/options.go
+++ b/auth/providers/azure/options.go
@@ -54,14 +54,12 @@ type Options struct {
 	SkipGroupMembershipResolution            bool
 	VerifyClientID                           bool
 	ResourceId                               string
-	MSIAudience                              string
 	AzureRegion                              string
 }
 
 func NewOptions() Options {
 	return Options{
 		ClientSecret: os.Getenv("AZURE_CLIENT_SECRET"),
-		MSIAudience:  os.Getenv("MSI_AUDIENCE"),
 		UseGroupUID:  true,
 	}
 }
@@ -114,18 +112,20 @@ func (o *Options) Validate() []error {
 		}
 	}
 
-	if o.AuthMode == ARCAuthMode && o.ResourceId == "" {
-		errs = append(errs, errors.New("azure.resource-id must be non-empty for authentication using arc mode"))
-	}
+	if o.AuthMode == ARCAuthMode {
+		if o.ResourceId == "" {
+			errs = append(errs, errors.New("azure.resource-id must be non-empty for authentication using arc mode"))
+		}
 
-	if o.AuthMode == ARCAuthMode && o.AzureRegion == "" {
-		errs = append(errs, errors.New("azure.region must be non-empty for authentication using arc mode"))
+		if o.AzureRegion == "" {
+			errs = append(errs, errors.New("azure.region must be non-empty for authentication using arc mode"))
+		}
 	}
 
 	if o.TenantID == "" {
 		errs = append(errs, errors.New("azure.tenant-id must be non-empty"))
 	}
-	if o.AuthMode != ARCAuthMode && o.VerifyClientID && o.ClientID == "" {
+	if o.VerifyClientID && o.ClientID == "" {
 		errs = append(errs, errors.New("azure.client-id must be non-empty when azure.verify-clientID is set"))
 	}
 	if o.EnablePOP && o.POPTokenHostname == "" {

--- a/auth/providers/azure/options.go
+++ b/auth/providers/azure/options.go
@@ -78,6 +78,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.ResolveGroupMembershipOnlyOnOverageClaim, "azure.graph-call-on-overage-claim", o.ResolveGroupMembershipOnlyOnOverageClaim, "set to true to resolve group membership only when overage claim is present. setting to false will always call graph api to resolve group membership")
 	fs.BoolVar(&o.VerifyClientID, "azure.verify-clientID", o.VerifyClientID, "set to true to validate token's audience claim matches clientID")
 	fs.BoolVar(&o.SkipGroupMembershipResolution, "azure.skip-group-membership-resolution", false, "when set to true, this will bypass getting group membership from graph api")
+	// resource id and region are needed to retrieve user's security group info via Arc obo service
 	fs.StringVar(&o.ResourceId, "azure.auth-resource-id", "", "azure cluster resource id (//subscription/<subName>/resourcegroups/<RGname>/providers/Microsoft.Kubernetes/connectedClusters/<clustername> for connectedk8s) used for making getMemberGroups to ARC OBO service")
 	fs.StringVar(&o.AzureRegion, "azure.region", "", "region where cluster is deployed")
 }
@@ -119,6 +120,14 @@ func (o *Options) Validate() []error {
 
 		if o.AzureRegion == "" {
 			errs = append(errs, errors.New("azure.region must be non-empty for authentication using arc mode"))
+		}
+
+		if o.SkipGroupMembershipResolution {
+			errs = append(errs, errors.New("azure.skip-group-membership-resolution cannot be true when arc azure.auth-mode is used"))
+		}
+
+		if !o.ResolveGroupMembershipOnlyOnOverageClaim {
+			errs = append(errs, errors.New("azure.graph-call-on-overage-claim cannot be false when arc azure.auth-mode is used"))
 		}
 	}
 

--- a/auth/providers/azure/options.go
+++ b/auth/providers/azure/options.go
@@ -55,6 +55,7 @@ type Options struct {
 	VerifyClientID                           bool
 	ResourceId                               string
 	MSIAudience                              string
+	AzureRegion                              string
 }
 
 func NewOptions() Options {
@@ -80,6 +81,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.VerifyClientID, "azure.verify-clientID", o.VerifyClientID, "set to true to validate token's audience claim matches clientID")
 	fs.BoolVar(&o.SkipGroupMembershipResolution, "azure.skip-group-membership-resolution", false, "when set to true, this will bypass getting group membership from graph api")
 	fs.StringVar(&o.ResourceId, "azure.auth-resource-id", "", "azure cluster resource id (//subscription/<subName>/resourcegroups/<RGname>/providers/Microsoft.Kubernetes/connectedClusters/<clustername> for connectedk8s) used for making getMemberGroups to ARC OBO service")
+	fs.StringVar(&o.AzureRegion, "azure.region", "", "region where cluster is deployed")
 }
 
 func (o *Options) Validate() []error {
@@ -114,6 +116,10 @@ func (o *Options) Validate() []error {
 
 	if o.AuthMode == ARCAuthMode && o.ResourceId == "" {
 		errs = append(errs, errors.New("azure.resource-id must be non-empty for authentication using arc mode"))
+	}
+
+	if o.AuthMode == ARCAuthMode && o.AzureRegion == "" {
+		errs = append(errs, errors.New("azure.region must be non-empty for authentication using arc mode"))
 	}
 
 	if o.TenantID == "" {

--- a/auth/providers/azure/options.go
+++ b/auth/providers/azure/options.go
@@ -119,7 +119,7 @@ func (o *Options) Validate() []error {
 	if o.TenantID == "" {
 		errs = append(errs, errors.New("azure.tenant-id must be non-empty"))
 	}
-	if o.VerifyClientID && o.ClientID == "" {
+	if o.AuthMode != ARCAuthMode && o.VerifyClientID && o.ClientID == "" {
 		errs = append(errs, errors.New("azure.client-id must be non-empty when azure.verify-clientID is set"))
 	}
 	if o.EnablePOP && o.POPTokenHostname == "" {

--- a/auth/providers/azure/pop_tokenverifier.go
+++ b/auth/providers/azure/pop_tokenverifier.go
@@ -125,7 +125,7 @@ func (p *PoPTokenVerifier) ValidatePopToken(token string) (string, error) {
 			if klog.V(6).Enabled() {
 				klog.V(6).Infof("pop token validation running with hostName: %s. Request is coming for hostName: %s", p.hostName, reqHostName)
 			}
-			if !strings.EqualFold(reqHostName, p.hostName) {
+			if !strings.HasSuffix(reqHostName, p.hostName) {
 				return "", errors.Errorf("Invalid Pop token due to host mismatch. Expected: %q, received: %q", p.hostName, reqHostName)
 			}
 		} else {

--- a/auth/providers/azure/pop_tokenverifier.go
+++ b/auth/providers/azure/pop_tokenverifier.go
@@ -125,7 +125,7 @@ func (p *PoPTokenVerifier) ValidatePopToken(token string) (string, error) {
 			if klog.V(6).Enabled() {
 				klog.V(6).Infof("pop token validation running with hostName: %s. Request is coming for hostName: %s", p.hostName, reqHostName)
 			}
-			if !strings.HasSuffix(reqHostName, p.hostName) {
+			if !strings.EqualFold(reqHostName, p.hostName) {
 				return "", errors.Errorf("Invalid Pop token due to host mismatch. Expected: %q, received: %q", p.hostName, reqHostName)
 			}
 		} else {

--- a/authz/providers/azure/options/options.go
+++ b/authz/providers/azure/options/options.go
@@ -100,14 +100,14 @@ func (o *Options) Validate(azure azure.Options) []error {
 		errs = append(errs, errors.New("azure.aks-authz-token-url must be set only with AKS/Fleet authz mode"))
 	}
 
-	if o.AuthzMode == ARCAuthzMode {
-		if azure.ClientSecret == "" {
-			errs = append(errs, errors.New("azure.client-secret must be non-empty"))
-		}
-		if azure.ClientID == "" {
-			errs = append(errs, errors.New("azure.client-id must be non-empty"))
-		}
-	}
+	// if o.AuthzMode == ARCAuthzMode {
+	// 	if azure.ClientSecret == "" {
+	// 		errs = append(errs, errors.New("azure.client-secret must be non-empty"))
+	// 	}
+	// 	if azure.ClientID == "" {
+	// 		errs = append(errs, errors.New("azure.client-id must be non-empty"))
+	// 	}
+	// }
 
 	if o.ARMCallLimit > maxPermissibleArmCallLimit {
 		errs = append(errs, fmt.Errorf("azure.arm-call-limit must not be more than %d", maxPermissibleArmCallLimit))

--- a/authz/providers/azure/options/options.go
+++ b/authz/providers/azure/options/options.go
@@ -100,15 +100,6 @@ func (o *Options) Validate(azure azure.Options) []error {
 		errs = append(errs, errors.New("azure.aks-authz-token-url must be set only with AKS/Fleet authz mode"))
 	}
 
-	// if o.AuthzMode == ARCAuthzMode {
-	// 	if azure.ClientSecret == "" {
-	// 		errs = append(errs, errors.New("azure.client-secret must be non-empty"))
-	// 	}
-	// 	if azure.ClientID == "" {
-	// 		errs = append(errs, errors.New("azure.client-id must be non-empty"))
-	// 	}
-	// }
-
 	if o.ARMCallLimit > maxPermissibleArmCallLimit {
 		errs = append(errs, fmt.Errorf("azure.arm-call-limit must not be more than %d", maxPermissibleArmCallLimit))
 	}

--- a/authz/providers/azure/options/options.go
+++ b/authz/providers/azure/options/options.go
@@ -100,6 +100,12 @@ func (o *Options) Validate(azure azure.Options) []error {
 		errs = append(errs, errors.New("azure.aks-authz-token-url must be set only with AKS/Fleet authz mode"))
 	}
 
+	if o.AuthzMode == ARCAuthzMode {
+		if azure.ClientID == "" {
+			errs = append(errs, errors.New("azure.client-id must be non-empty"))
+		}
+	}
+
 	if o.ARMCallLimit > maxPermissibleArmCallLimit {
 		errs = append(errs, fmt.Errorf("azure.arm-call-limit must not be more than %d", maxPermissibleArmCallLimit))
 	}

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -199,7 +199,7 @@ func New(opts authzOpts.Options, authopts auth.Options, authzInfo *AuthzInfo) (*
 				fmt.Sprintf("%s%s/oauth2/v2.0/token", authzInfo.AADEndpoint, authopts.TenantID),
 				fmt.Sprintf("%s.default", authzInfo.ARMEndPoint))
 		} else {
-			tokenProvider = graph.NewMSITokenProvider(authzInfo.ARMEndPoint, graph.MSIEndpointForARC, opts.ResourceId)
+			tokenProvider = graph.NewMSITokenProvider(authzInfo.ARMEndPoint, graph.MSIEndpointForARC)
 		}
 	case authzOpts.FleetAuthzMode:
 		tokenProvider = graph.NewAKSTokenProvider(opts.AKSAuthzTokenURL, authopts.TenantID)

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -199,7 +199,7 @@ func New(opts authzOpts.Options, authopts auth.Options, authzInfo *AuthzInfo) (*
 				fmt.Sprintf("%s%s/oauth2/v2.0/token", authzInfo.AADEndpoint, authopts.TenantID),
 				fmt.Sprintf("%s.default", authzInfo.ARMEndPoint))
 		} else {
-			tokenProvider = graph.NewMSITokenProvider(authzInfo.ARMEndPoint, graph.MSIEndpointForARC)
+			tokenProvider = graph.NewMSITokenProvider(authzInfo.ARMEndPoint, graph.MSIEndpointForARC, opts.ResourceId)
 		}
 	case authzOpts.FleetAuthzMode:
 		tokenProvider = graph.NewAKSTokenProvider(opts.AKSAuthzTokenURL, authopts.TenantID)

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -193,9 +193,14 @@ func New(opts authzOpts.Options, authopts auth.Options, authzInfo *AuthzInfo) (*
 	var tokenProvider graph.TokenProvider
 	switch opts.AuthzMode {
 	case authzOpts.ARCAuthzMode:
-		tokenProvider = graph.NewClientCredentialTokenProvider(authopts.ClientID, authopts.ClientSecret,
-			fmt.Sprintf("%s%s/oauth2/v2.0/token", authzInfo.AADEndpoint, authopts.TenantID),
-			fmt.Sprintf("%s.default", authzInfo.ARMEndPoint))
+		// client id and secret check use old provider
+		if authopts.ClientID != "" && authopts.ClientSecret != "" {
+			tokenProvider = graph.NewClientCredentialTokenProvider(authopts.ClientID, authopts.ClientSecret,
+				fmt.Sprintf("%s%s/oauth2/v2.0/token", authzInfo.AADEndpoint, authopts.TenantID),
+				fmt.Sprintf("%s.default", authzInfo.ARMEndPoint))
+		} else {
+			tokenProvider = graph.NewMSITokenProvider(authzInfo.ARMEndPoint, graph.MSIEndpointForARC)
+		}
 	case authzOpts.FleetAuthzMode:
 		tokenProvider = graph.NewAKSTokenProvider(opts.AKSAuthzTokenURL, authopts.TenantID)
 	case authzOpts.AKSAuthzMode:

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -193,8 +193,8 @@ func New(opts authzOpts.Options, authopts auth.Options, authzInfo *AuthzInfo) (*
 	var tokenProvider graph.TokenProvider
 	switch opts.AuthzMode {
 	case authzOpts.ARCAuthzMode:
-		// client id and secret check use old provider
-		if authopts.ClientID != "" && authopts.ClientSecret != "" {
+		// if client secret is there check use client credential provider
+		if authopts.ClientSecret != "" {
 			tokenProvider = graph.NewClientCredentialTokenProvider(authopts.ClientID, authopts.ClientSecret,
 				fmt.Sprintf("%s%s/oauth2/v2.0/token", authzInfo.AADEndpoint, authopts.TenantID),
 				fmt.Sprintf("%s.default", authzInfo.ARMEndPoint))

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
 	kmodules.xyz/client-go v0.25.18
+	github.com/golang-jwt/jwt/v5 v5.0.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-ldap/ldap/v3 v3.4.4
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-github/v50 v50.1.0
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.3.0
@@ -48,7 +49,6 @@ require (
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
 	kmodules.xyz/client-go v0.25.18
-	github.com/golang-jwt/jwt/v5 v5.0.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -37,7 +37,6 @@ export GOFLAGS="-mod=vendor"
 
 go install \
     -installsuffix "static" \
-    -buildvcs=false \
     -ldflags "                                          \
       -X main.Version=${VERSION}                        \
       -X main.VersionStrategy=${version_strategy:-}     \

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -37,6 +37,7 @@ export GOFLAGS="-mod=vendor"
 
 go install \
     -installsuffix "static" \
+    -buildvcs=false \
     -ldflags "                                          \
       -X main.Version=${VERSION}                        \
       -X main.VersionStrategy=${version_strategy:-}     \

--- a/vendor/github.com/golang-jwt/jwt/.gitignore
+++ b/vendor/github.com/golang-jwt/jwt/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+bin
+.idea/
+

--- a/vendor/github.com/golang-jwt/jwt/LICENSE
+++ b/vendor/github.com/golang-jwt/jwt/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) 2012 Dave Grijalva
+Copyright (c) 2021 golang-jwt maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/vendor/github.com/golang-jwt/jwt/MIGRATION_GUIDE.md
+++ b/vendor/github.com/golang-jwt/jwt/MIGRATION_GUIDE.md
@@ -1,0 +1,22 @@
+## Migration Guide (v3.2.1)
+
+Starting from [v3.2.1](https://github.com/golang-jwt/jwt/releases/tag/v3.2.1]), the import path has changed from `github.com/dgrijalva/jwt-go` to `github.com/golang-jwt/jwt`. Future releases will be using the `github.com/golang-jwt/jwt` import path and continue the existing versioning scheme of `v3.x.x+incompatible`. Backwards-compatible patches and fixes will be done on the `v3` release branch, where as new build-breaking features will be developed in a `v4` release, possibly including a SIV-style import path.
+
+### go.mod replacement
+
+In a first step, the easiest way is to use `go mod edit` to issue a replacement.
+
+```
+go mod edit -replace github.com/dgrijalva/jwt-go=github.com/golang-jwt/jwt@v3.2.1+incompatible
+go mod tidy
+```
+
+This will still keep the old import path in your code but replace it with the new package and also introduce a new indirect dependency to `github.com/golang-jwt/jwt`. Try to compile your project; it should still work.
+
+### Cleanup
+
+If your code still consistently builds, you can replace all occurences of `github.com/dgrijalva/jwt-go` with `github.com/golang-jwt/jwt`, either manually or by using tools such as `sed`. Finally, the `replace` directive in the `go.mod` file can be removed.
+
+## Older releases (before v3.2.0)
+
+The original migration guide for older releases can be found at https://github.com/dgrijalva/jwt-go/blob/master/MIGRATION_GUIDE.md.

--- a/vendor/github.com/golang-jwt/jwt/README.md
+++ b/vendor/github.com/golang-jwt/jwt/README.md
@@ -1,0 +1,113 @@
+# jwt-go
+
+[![build](https://github.com/golang-jwt/jwt/actions/workflows/build.yml/badge.svg)](https://github.com/golang-jwt/jwt/actions/workflows/build.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/golang-jwt/jwt.svg)](https://pkg.go.dev/github.com/golang-jwt/jwt)
+
+A [go](http://www.golang.org) (or 'golang' for search engine friendliness) implementation of [JSON Web Tokens](https://datatracker.ietf.org/doc/html/rfc7519).
+
+**IMPORT PATH CHANGE:** Starting from [v3.2.1](https://github.com/golang-jwt/jwt/releases/tag/v3.2.1), the import path has changed from `github.com/dgrijalva/jwt-go` to `github.com/golang-jwt/jwt`. After the original author of the library suggested migrating the maintenance of `jwt-go`, a dedicated team of open source maintainers decided to clone the existing library into this repository. See [dgrijalva/jwt-go#462](https://github.com/dgrijalva/jwt-go/issues/462) for a detailed discussion on this topic.
+
+Future releases will be using the `github.com/golang-jwt/jwt` import path and continue the existing versioning scheme of `v3.x.x+incompatible`. Backwards-compatible patches and fixes will be done on the `v3` release branch, where as new build-breaking features will be developed in a `v4` release, possibly including a SIV-style import path.
+
+**SECURITY NOTICE:** Some older versions of Go have a security issue in the crypto/elliptic. Recommendation is to upgrade to at least 1.15 See issue [dgrijalva/jwt-go#216](https://github.com/dgrijalva/jwt-go/issues/216) for more detail.
+
+**SECURITY NOTICE:** It's important that you [validate the `alg` presented is what you expect](https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/). This library attempts to make it easy to do the right thing by requiring key types match the expected alg, but you should take the extra step to verify it in your usage.  See the examples provided.
+
+### Supported Go versions
+
+Our support of Go versions is aligned with Go's [version release policy](https://golang.org/doc/devel/release#policy).
+So we will support a major version of Go until there are two newer major releases.
+We no longer support building jwt-go with unsupported Go versions, as these contain security vulnerabilities
+which will not be fixed.
+
+## What the heck is a JWT?
+
+JWT.io has [a great introduction](https://jwt.io/introduction) to JSON Web Tokens.
+
+In short, it's a signed JSON object that does something useful (for example, authentication).  It's commonly used for `Bearer` tokens in Oauth 2.  A token is made of three parts, separated by `.`'s.  The first two parts are JSON objects, that have been [base64url](https://datatracker.ietf.org/doc/html/rfc4648) encoded.  The last part is the signature, encoded the same way.
+
+The first part is called the header.  It contains the necessary information for verifying the last part, the signature.  For example, which encryption method was used for signing and what key was used.
+
+The part in the middle is the interesting bit.  It's called the Claims and contains the actual stuff you care about.  Refer to [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519) for information about reserved keys and the proper way to add your own.
+
+## What's in the box?
+
+This library supports the parsing and verification as well as the generation and signing of JWTs.  Current supported signing algorithms are HMAC SHA, RSA, RSA-PSS, and ECDSA, though hooks are present for adding your own.
+
+## Examples
+
+See [the project documentation](https://pkg.go.dev/github.com/golang-jwt/jwt) for examples of usage:
+
+* [Simple example of parsing and validating a token](https://pkg.go.dev/github.com/golang-jwt/jwt#example-Parse-Hmac)
+* [Simple example of building and signing a token](https://pkg.go.dev/github.com/golang-jwt/jwt#example-New-Hmac)
+* [Directory of Examples](https://pkg.go.dev/github.com/golang-jwt/jwt#pkg-examples)
+
+## Extensions
+
+This library publishes all the necessary components for adding your own signing methods.  Simply implement the `SigningMethod` interface and register a factory method using `RegisterSigningMethod`.  
+
+Here's an example of an extension that integrates with multiple Google Cloud Platform signing tools (AppEngine, IAM API, Cloud KMS): https://github.com/someone1/gcp-jwt-go
+
+## Compliance
+
+This library was last reviewed to comply with [RTF 7519](https://datatracker.ietf.org/doc/html/rfc7519) dated May 2015 with a few notable differences:
+
+* In order to protect against accidental use of [Unsecured JWTs](https://datatracker.ietf.org/doc/html/rfc7519#section-6), tokens using `alg=none` will only be accepted if the constant `jwt.UnsafeAllowNoneSignatureType` is provided as the key.
+
+## Project Status & Versioning
+
+This library is considered production ready.  Feedback and feature requests are appreciated.  The API should be considered stable.  There should be very few backwards-incompatible changes outside of major version updates (and only with good reason).
+
+This project uses [Semantic Versioning 2.0.0](http://semver.org).  Accepted pull requests will land on `main`.  Periodically, versions will be tagged from `main`.  You can find all the releases on [the project releases page](https://github.com/golang-jwt/jwt/releases).
+
+While we try to make it obvious when we make breaking changes, there isn't a great mechanism for pushing announcements out to users.  You may want to use this alternative package include: `gopkg.in/golang-jwt/jwt.v3`.  It will do the right thing WRT semantic versioning.
+
+**BREAKING CHANGES:*** 
+* Version 3.0.0 includes _a lot_ of changes from the 2.x line, including a few that break the API.  We've tried to break as few things as possible, so there should just be a few type signature changes.  A full list of breaking changes is available in `VERSION_HISTORY.md`.  See `MIGRATION_GUIDE.md` for more information on updating your code.
+
+## Usage Tips
+
+### Signing vs Encryption
+
+A token is simply a JSON object that is signed by its author. this tells you exactly two things about the data:
+
+* The author of the token was in the possession of the signing secret
+* The data has not been modified since it was signed
+
+It's important to know that JWT does not provide encryption, which means anyone who has access to the token can read its contents. If you need to protect (encrypt) the data, there is a companion spec, `JWE`, that provides this functionality. JWE is currently outside the scope of this library.
+
+### Choosing a Signing Method
+
+There are several signing methods available, and you should probably take the time to learn about the various options before choosing one.  The principal design decision is most likely going to be symmetric vs asymmetric.
+
+Symmetric signing methods, such as HSA, use only a single secret. This is probably the simplest signing method to use since any `[]byte` can be used as a valid secret. They are also slightly computationally faster to use, though this rarely is enough to matter. Symmetric signing methods work the best when both producers and consumers of tokens are trusted, or even the same system. Since the same secret is used to both sign and validate tokens, you can't easily distribute the key for validation.
+
+Asymmetric signing methods, such as RSA, use different keys for signing and verifying tokens. This makes it possible to produce tokens with a private key, and allow any consumer to access the public key for verification.
+
+### Signing Methods and Key Types
+
+Each signing method expects a different object type for its signing keys. See the package documentation for details. Here are the most common ones:
+
+* The [HMAC signing method](https://pkg.go.dev/github.com/golang-jwt/jwt#SigningMethodHMAC) (`HS256`,`HS384`,`HS512`) expect `[]byte` values for signing and validation
+* The [RSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt#SigningMethodRSA) (`RS256`,`RS384`,`RS512`) expect `*rsa.PrivateKey` for signing and `*rsa.PublicKey` for validation
+* The [ECDSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt#SigningMethodECDSA) (`ES256`,`ES384`,`ES512`) expect `*ecdsa.PrivateKey` for signing and `*ecdsa.PublicKey` for validation
+
+### JWT and OAuth
+
+It's worth mentioning that OAuth and JWT are not the same thing. A JWT token is simply a signed JSON object. It can be used anywhere such a thing is useful. There is some confusion, though, as JWT is the most common type of bearer token used in OAuth2 authentication.
+
+Without going too far down the rabbit hole, here's a description of the interaction of these technologies:
+
+* OAuth is a protocol for allowing an identity provider to be separate from the service a user is logging in to. For example, whenever you use Facebook to log into a different service (Yelp, Spotify, etc), you are using OAuth.
+* OAuth defines several options for passing around authentication data. One popular method is called a "bearer token". A bearer token is simply a string that _should_ only be held by an authenticated user. Thus, simply presenting this token proves your identity. You can probably derive from here why a JWT might make a good bearer token.
+* Because bearer tokens are used for authentication, it's important they're kept secret. This is why transactions that use bearer tokens typically happen over SSL.
+
+### Troubleshooting
+
+This library uses descriptive error messages whenever possible. If you are not getting the expected result, have a look at the errors. The most common place people get stuck is providing the correct type of key to the parser. See the above section on signing methods and key types.
+
+## More
+
+Documentation can be found [on pkg.go.dev](https://pkg.go.dev/github.com/golang-jwt/jwt).
+
+The command line utility included in this project (cmd/jwt) provides a straightforward example of token creation and parsing as well as a useful tool for debugging your own integration. You'll also find several implementation examples in the documentation.

--- a/vendor/github.com/golang-jwt/jwt/VERSION_HISTORY.md
+++ b/vendor/github.com/golang-jwt/jwt/VERSION_HISTORY.md
@@ -1,0 +1,131 @@
+## `jwt-go` Version History
+
+#### 3.2.2
+
+* Starting from this release, we are adopting the policy to support the most 2 recent versions of Go currently available. By the time of this release, this is Go 1.15 and 1.16 ([#28](https://github.com/golang-jwt/jwt/pull/28)).
+* Fixed a potential issue that could occur when the verification of `exp`, `iat` or `nbf` was not required and contained invalid contents, i.e. non-numeric/date. Thanks for @thaJeztah for making us aware of that and @giorgos-f3 for originally reporting it to the formtech fork ([#40](https://github.com/golang-jwt/jwt/pull/40)).
+* Added support for EdDSA / ED25519 ([#36](https://github.com/golang-jwt/jwt/pull/36)).
+* Optimized allocations ([#33](https://github.com/golang-jwt/jwt/pull/33)).
+
+#### 3.2.1
+
+* **Import Path Change**: See MIGRATION_GUIDE.md for tips on updating your code
+	* Changed the import path from `github.com/dgrijalva/jwt-go` to `github.com/golang-jwt/jwt`
+* Fixed type confusing issue between `string` and `[]string` in `VerifyAudience` ([#12](https://github.com/golang-jwt/jwt/pull/12)). This fixes CVE-2020-26160 
+
+#### 3.2.0
+
+* Added method `ParseUnverified` to allow users to split up the tasks of parsing and validation
+* HMAC signing method returns `ErrInvalidKeyType` instead of `ErrInvalidKey` where appropriate
+* Added options to `request.ParseFromRequest`, which allows for an arbitrary list of modifiers to parsing behavior. Initial set include `WithClaims` and `WithParser`. Existing usage of this function will continue to work as before.
+* Deprecated `ParseFromRequestWithClaims` to simplify API in the future.
+
+#### 3.1.0
+
+* Improvements to `jwt` command line tool
+* Added `SkipClaimsValidation` option to `Parser`
+* Documentation updates
+
+#### 3.0.0
+
+* **Compatibility Breaking Changes**: See MIGRATION_GUIDE.md for tips on updating your code
+	* Dropped support for `[]byte` keys when using RSA signing methods.  This convenience feature could contribute to security vulnerabilities involving mismatched key types with signing methods.
+	* `ParseFromRequest` has been moved to `request` subpackage and usage has changed
+	* The `Claims` property on `Token` is now type `Claims` instead of `map[string]interface{}`.  The default value is type `MapClaims`, which is an alias to `map[string]interface{}`.  This makes it possible to use a custom type when decoding claims.
+* Other Additions and Changes
+	* Added `Claims` interface type to allow users to decode the claims into a custom type
+	* Added `ParseWithClaims`, which takes a third argument of type `Claims`.  Use this function instead of `Parse` if you have a custom type you'd like to decode into.
+	* Dramatically improved the functionality and flexibility of `ParseFromRequest`, which is now in the `request` subpackage
+	* Added `ParseFromRequestWithClaims` which is the `FromRequest` equivalent of `ParseWithClaims`
+	* Added new interface type `Extractor`, which is used for extracting JWT strings from http requests.  Used with `ParseFromRequest` and `ParseFromRequestWithClaims`.
+	* Added several new, more specific, validation errors to error type bitmask
+	* Moved examples from README to executable example files
+	* Signing method registry is now thread safe
+	* Added new property to `ValidationError`, which contains the raw error returned by calls made by parse/verify (such as those returned by keyfunc or json parser)
+
+#### 2.7.0
+
+This will likely be the last backwards compatible release before 3.0.0, excluding essential bug fixes.
+
+* Added new option `-show` to the `jwt` command that will just output the decoded token without verifying
+* Error text for expired tokens includes how long it's been expired
+* Fixed incorrect error returned from `ParseRSAPublicKeyFromPEM`
+* Documentation updates
+
+#### 2.6.0
+
+* Exposed inner error within ValidationError
+* Fixed validation errors when using UseJSONNumber flag
+* Added several unit tests
+
+#### 2.5.0
+
+* Added support for signing method none.  You shouldn't use this.  The API tries to make this clear.
+* Updated/fixed some documentation
+* Added more helpful error message when trying to parse tokens that begin with `BEARER `
+
+#### 2.4.0
+
+* Added new type, Parser, to allow for configuration of various parsing parameters
+	* You can now specify a list of valid signing methods.  Anything outside this set will be rejected.
+	* You can now opt to use the `json.Number` type instead of `float64` when parsing token JSON
+* Added support for [Travis CI](https://travis-ci.org/dgrijalva/jwt-go)
+* Fixed some bugs with ECDSA parsing
+
+#### 2.3.0
+
+* Added support for ECDSA signing methods
+* Added support for RSA PSS signing methods (requires go v1.4)
+
+#### 2.2.0
+
+* Gracefully handle a `nil` `Keyfunc` being passed to `Parse`.  Result will now be the parsed token and an error, instead of a panic.
+
+#### 2.1.0
+
+Backwards compatible API change that was missed in 2.0.0.
+
+* The `SignedString` method on `Token` now takes `interface{}` instead of `[]byte`
+
+#### 2.0.0
+
+There were two major reasons for breaking backwards compatibility with this update.  The first was a refactor required to expand the width of the RSA and HMAC-SHA signing implementations.  There will likely be no required code changes to support this change.
+
+The second update, while unfortunately requiring a small change in integration, is required to open up this library to other signing methods.  Not all keys used for all signing methods have a single standard on-disk representation.  Requiring `[]byte` as the type for all keys proved too limiting.  Additionally, this implementation allows for pre-parsed tokens to be reused, which might matter in an application that parses a high volume of tokens with a small set of keys.  Backwards compatibilty has been maintained for passing `[]byte` to the RSA signing methods, but they will also accept `*rsa.PublicKey` and `*rsa.PrivateKey`.
+
+It is likely the only integration change required here will be to change `func(t *jwt.Token) ([]byte, error)` to `func(t *jwt.Token) (interface{}, error)` when calling `Parse`.
+
+* **Compatibility Breaking Changes**
+	* `SigningMethodHS256` is now `*SigningMethodHMAC` instead of `type struct`
+	* `SigningMethodRS256` is now `*SigningMethodRSA` instead of `type struct`
+	* `KeyFunc` now returns `interface{}` instead of `[]byte`
+	* `SigningMethod.Sign` now takes `interface{}` instead of `[]byte` for the key
+	* `SigningMethod.Verify` now takes `interface{}` instead of `[]byte` for the key
+* Renamed type `SigningMethodHS256` to `SigningMethodHMAC`.  Specific sizes are now just instances of this type.
+    * Added public package global `SigningMethodHS256`
+    * Added public package global `SigningMethodHS384`
+    * Added public package global `SigningMethodHS512`
+* Renamed type `SigningMethodRS256` to `SigningMethodRSA`.  Specific sizes are now just instances of this type.
+    * Added public package global `SigningMethodRS256`
+    * Added public package global `SigningMethodRS384`
+    * Added public package global `SigningMethodRS512`
+* Moved sample private key for HMAC tests from an inline value to a file on disk.  Value is unchanged.
+* Refactored the RSA implementation to be easier to read
+* Exposed helper methods `ParseRSAPrivateKeyFromPEM` and `ParseRSAPublicKeyFromPEM`
+
+#### 1.0.2
+
+* Fixed bug in parsing public keys from certificates
+* Added more tests around the parsing of keys for RS256
+* Code refactoring in RS256 implementation.  No functional changes
+
+#### 1.0.1
+
+* Fixed panic if RS256 signing method was passed an invalid key
+
+#### 1.0.0
+
+* First versioned release
+* API stabilized
+* Supports creating, signing, parsing, and validating JWT tokens
+* Supports RS256 and HS256 signing methods

--- a/vendor/github.com/golang-jwt/jwt/claims.go
+++ b/vendor/github.com/golang-jwt/jwt/claims.go
@@ -1,0 +1,146 @@
+package jwt
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"time"
+)
+
+// For a type to be a Claims object, it must just have a Valid method that determines
+// if the token is invalid for any supported reason
+type Claims interface {
+	Valid() error
+}
+
+// Structured version of Claims Section, as referenced at
+// https://tools.ietf.org/html/rfc7519#section-4.1
+// See examples for how to use this with your own claim types
+type StandardClaims struct {
+	Audience  string `json:"aud,omitempty"`
+	ExpiresAt int64  `json:"exp,omitempty"`
+	Id        string `json:"jti,omitempty"`
+	IssuedAt  int64  `json:"iat,omitempty"`
+	Issuer    string `json:"iss,omitempty"`
+	NotBefore int64  `json:"nbf,omitempty"`
+	Subject   string `json:"sub,omitempty"`
+}
+
+// Validates time based claims "exp, iat, nbf".
+// There is no accounting for clock skew.
+// As well, if any of the above claims are not in the token, it will still
+// be considered a valid claim.
+func (c StandardClaims) Valid() error {
+	vErr := new(ValidationError)
+	now := TimeFunc().Unix()
+
+	// The claims below are optional, by default, so if they are set to the
+	// default value in Go, let's not fail the verification for them.
+	if !c.VerifyExpiresAt(now, false) {
+		delta := time.Unix(now, 0).Sub(time.Unix(c.ExpiresAt, 0))
+		vErr.Inner = fmt.Errorf("token is expired by %v", delta)
+		vErr.Errors |= ValidationErrorExpired
+	}
+
+	if !c.VerifyIssuedAt(now, false) {
+		vErr.Inner = fmt.Errorf("Token used before issued")
+		vErr.Errors |= ValidationErrorIssuedAt
+	}
+
+	if !c.VerifyNotBefore(now, false) {
+		vErr.Inner = fmt.Errorf("token is not valid yet")
+		vErr.Errors |= ValidationErrorNotValidYet
+	}
+
+	if vErr.valid() {
+		return nil
+	}
+
+	return vErr
+}
+
+// Compares the aud claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyAudience(cmp string, req bool) bool {
+	return verifyAud([]string{c.Audience}, cmp, req)
+}
+
+// Compares the exp claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyExpiresAt(cmp int64, req bool) bool {
+	return verifyExp(c.ExpiresAt, cmp, req)
+}
+
+// Compares the iat claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyIssuedAt(cmp int64, req bool) bool {
+	return verifyIat(c.IssuedAt, cmp, req)
+}
+
+// Compares the iss claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyIssuer(cmp string, req bool) bool {
+	return verifyIss(c.Issuer, cmp, req)
+}
+
+// Compares the nbf claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyNotBefore(cmp int64, req bool) bool {
+	return verifyNbf(c.NotBefore, cmp, req)
+}
+
+// ----- helpers
+
+func verifyAud(aud []string, cmp string, required bool) bool {
+	if len(aud) == 0 {
+		return !required
+	}
+	// use a var here to keep constant time compare when looping over a number of claims
+	result := false
+
+	var stringClaims string
+	for _, a := range aud {
+		if subtle.ConstantTimeCompare([]byte(a), []byte(cmp)) != 0 {
+			result = true
+		}
+		stringClaims = stringClaims + a
+	}
+
+	// case where "" is sent in one or many aud claims
+	if len(stringClaims) == 0 {
+		return !required
+	}
+
+	return result
+}
+
+func verifyExp(exp int64, now int64, required bool) bool {
+	if exp == 0 {
+		return !required
+	}
+	return now <= exp
+}
+
+func verifyIat(iat int64, now int64, required bool) bool {
+	if iat == 0 {
+		return !required
+	}
+	return now >= iat
+}
+
+func verifyIss(iss string, cmp string, required bool) bool {
+	if iss == "" {
+		return !required
+	}
+	if subtle.ConstantTimeCompare([]byte(iss), []byte(cmp)) != 0 {
+		return true
+	} else {
+		return false
+	}
+}
+
+func verifyNbf(nbf int64, now int64, required bool) bool {
+	if nbf == 0 {
+		return !required
+	}
+	return now >= nbf
+}

--- a/vendor/github.com/golang-jwt/jwt/doc.go
+++ b/vendor/github.com/golang-jwt/jwt/doc.go
@@ -1,0 +1,4 @@
+// Package jwt is a Go implementation of JSON Web Tokens: http://self-issued.info/docs/draft-jones-json-web-token.html
+//
+// See README.md for more info.
+package jwt

--- a/vendor/github.com/golang-jwt/jwt/ecdsa.go
+++ b/vendor/github.com/golang-jwt/jwt/ecdsa.go
@@ -1,0 +1,142 @@
+package jwt
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"errors"
+	"math/big"
+)
+
+var (
+	// Sadly this is missing from crypto/ecdsa compared to crypto/rsa
+	ErrECDSAVerification = errors.New("crypto/ecdsa: verification error")
+)
+
+// Implements the ECDSA family of signing methods signing methods
+// Expects *ecdsa.PrivateKey for signing and *ecdsa.PublicKey for verification
+type SigningMethodECDSA struct {
+	Name      string
+	Hash      crypto.Hash
+	KeySize   int
+	CurveBits int
+}
+
+// Specific instances for EC256 and company
+var (
+	SigningMethodES256 *SigningMethodECDSA
+	SigningMethodES384 *SigningMethodECDSA
+	SigningMethodES512 *SigningMethodECDSA
+)
+
+func init() {
+	// ES256
+	SigningMethodES256 = &SigningMethodECDSA{"ES256", crypto.SHA256, 32, 256}
+	RegisterSigningMethod(SigningMethodES256.Alg(), func() SigningMethod {
+		return SigningMethodES256
+	})
+
+	// ES384
+	SigningMethodES384 = &SigningMethodECDSA{"ES384", crypto.SHA384, 48, 384}
+	RegisterSigningMethod(SigningMethodES384.Alg(), func() SigningMethod {
+		return SigningMethodES384
+	})
+
+	// ES512
+	SigningMethodES512 = &SigningMethodECDSA{"ES512", crypto.SHA512, 66, 521}
+	RegisterSigningMethod(SigningMethodES512.Alg(), func() SigningMethod {
+		return SigningMethodES512
+	})
+}
+
+func (m *SigningMethodECDSA) Alg() string {
+	return m.Name
+}
+
+// Implements the Verify method from SigningMethod
+// For this verify method, key must be an ecdsa.PublicKey struct
+func (m *SigningMethodECDSA) Verify(signingString, signature string, key interface{}) error {
+	var err error
+
+	// Decode the signature
+	var sig []byte
+	if sig, err = DecodeSegment(signature); err != nil {
+		return err
+	}
+
+	// Get the key
+	var ecdsaKey *ecdsa.PublicKey
+	switch k := key.(type) {
+	case *ecdsa.PublicKey:
+		ecdsaKey = k
+	default:
+		return ErrInvalidKeyType
+	}
+
+	if len(sig) != 2*m.KeySize {
+		return ErrECDSAVerification
+	}
+
+	r := big.NewInt(0).SetBytes(sig[:m.KeySize])
+	s := big.NewInt(0).SetBytes(sig[m.KeySize:])
+
+	// Create hasher
+	if !m.Hash.Available() {
+		return ErrHashUnavailable
+	}
+	hasher := m.Hash.New()
+	hasher.Write([]byte(signingString))
+
+	// Verify the signature
+	if verifystatus := ecdsa.Verify(ecdsaKey, hasher.Sum(nil), r, s); verifystatus {
+		return nil
+	}
+
+	return ErrECDSAVerification
+}
+
+// Implements the Sign method from SigningMethod
+// For this signing method, key must be an ecdsa.PrivateKey struct
+func (m *SigningMethodECDSA) Sign(signingString string, key interface{}) (string, error) {
+	// Get the key
+	var ecdsaKey *ecdsa.PrivateKey
+	switch k := key.(type) {
+	case *ecdsa.PrivateKey:
+		ecdsaKey = k
+	default:
+		return "", ErrInvalidKeyType
+	}
+
+	// Create the hasher
+	if !m.Hash.Available() {
+		return "", ErrHashUnavailable
+	}
+
+	hasher := m.Hash.New()
+	hasher.Write([]byte(signingString))
+
+	// Sign the string and return r, s
+	if r, s, err := ecdsa.Sign(rand.Reader, ecdsaKey, hasher.Sum(nil)); err == nil {
+		curveBits := ecdsaKey.Curve.Params().BitSize
+
+		if m.CurveBits != curveBits {
+			return "", ErrInvalidKey
+		}
+
+		keyBytes := curveBits / 8
+		if curveBits%8 > 0 {
+			keyBytes += 1
+		}
+
+		// We serialize the outputs (r and s) into big-endian byte arrays
+		// padded with zeros on the left to make sure the sizes work out.
+		// Output must be 2*keyBytes long.
+		out := make([]byte, 2*keyBytes)
+		r.FillBytes(out[0:keyBytes]) // r is assigned to the first half of output.
+		s.FillBytes(out[keyBytes:])  // s is assigned to the second half of output.
+
+		return EncodeSegment(out), nil
+	} else {
+		return "", err
+	}
+}

--- a/vendor/github.com/golang-jwt/jwt/ecdsa_utils.go
+++ b/vendor/github.com/golang-jwt/jwt/ecdsa_utils.go
@@ -1,0 +1,69 @@
+package jwt
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+)
+
+var (
+	ErrNotECPublicKey  = errors.New("Key is not a valid ECDSA public key")
+	ErrNotECPrivateKey = errors.New("Key is not a valid ECDSA private key")
+)
+
+// Parse PEM encoded Elliptic Curve Private Key Structure
+func ParseECPrivateKeyFromPEM(key []byte) (*ecdsa.PrivateKey, error) {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		return nil, ErrKeyMustBePEMEncoded
+	}
+
+	// Parse the key
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParseECPrivateKey(block.Bytes); err != nil {
+		if parsedKey, err = x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+			return nil, err
+		}
+	}
+
+	var pkey *ecdsa.PrivateKey
+	var ok bool
+	if pkey, ok = parsedKey.(*ecdsa.PrivateKey); !ok {
+		return nil, ErrNotECPrivateKey
+	}
+
+	return pkey, nil
+}
+
+// Parse PEM encoded PKCS1 or PKCS8 public key
+func ParseECPublicKeyFromPEM(key []byte) (*ecdsa.PublicKey, error) {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		return nil, ErrKeyMustBePEMEncoded
+	}
+
+	// Parse the key
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParsePKIXPublicKey(block.Bytes); err != nil {
+		if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+			parsedKey = cert.PublicKey
+		} else {
+			return nil, err
+		}
+	}
+
+	var pkey *ecdsa.PublicKey
+	var ok bool
+	if pkey, ok = parsedKey.(*ecdsa.PublicKey); !ok {
+		return nil, ErrNotECPublicKey
+	}
+
+	return pkey, nil
+}

--- a/vendor/github.com/golang-jwt/jwt/ed25519.go
+++ b/vendor/github.com/golang-jwt/jwt/ed25519.go
@@ -1,0 +1,81 @@
+package jwt
+
+import (
+	"errors"
+
+	"crypto/ed25519"
+)
+
+var (
+	ErrEd25519Verification = errors.New("ed25519: verification error")
+)
+
+// Implements the EdDSA family
+// Expects ed25519.PrivateKey for signing and ed25519.PublicKey for verification
+type SigningMethodEd25519 struct{}
+
+// Specific instance for EdDSA
+var (
+	SigningMethodEdDSA *SigningMethodEd25519
+)
+
+func init() {
+	SigningMethodEdDSA = &SigningMethodEd25519{}
+	RegisterSigningMethod(SigningMethodEdDSA.Alg(), func() SigningMethod {
+		return SigningMethodEdDSA
+	})
+}
+
+func (m *SigningMethodEd25519) Alg() string {
+	return "EdDSA"
+}
+
+// Implements the Verify method from SigningMethod
+// For this verify method, key must be an ed25519.PublicKey
+func (m *SigningMethodEd25519) Verify(signingString, signature string, key interface{}) error {
+	var err error
+	var ed25519Key ed25519.PublicKey
+	var ok bool
+
+	if ed25519Key, ok = key.(ed25519.PublicKey); !ok {
+		return ErrInvalidKeyType
+	}
+
+	if len(ed25519Key) != ed25519.PublicKeySize {
+		return ErrInvalidKey
+	}
+
+	// Decode the signature
+	var sig []byte
+	if sig, err = DecodeSegment(signature); err != nil {
+		return err
+	}
+
+	// Verify the signature
+	if !ed25519.Verify(ed25519Key, []byte(signingString), sig) {
+		return ErrEd25519Verification
+	}
+
+	return nil
+}
+
+// Implements the Sign method from SigningMethod
+// For this signing method, key must be an ed25519.PrivateKey
+func (m *SigningMethodEd25519) Sign(signingString string, key interface{}) (string, error) {
+	var ed25519Key ed25519.PrivateKey
+	var ok bool
+
+	if ed25519Key, ok = key.(ed25519.PrivateKey); !ok {
+		return "", ErrInvalidKeyType
+	}
+
+	// ed25519.Sign panics if private key not equal to ed25519.PrivateKeySize
+	// this allows to avoid recover usage
+	if len(ed25519Key) != ed25519.PrivateKeySize {
+		return "", ErrInvalidKey
+	}
+
+	// Sign the string and return the encoded result
+	sig := ed25519.Sign(ed25519Key, []byte(signingString))
+	return EncodeSegment(sig), nil
+}

--- a/vendor/github.com/golang-jwt/jwt/ed25519_utils.go
+++ b/vendor/github.com/golang-jwt/jwt/ed25519_utils.go
@@ -1,0 +1,64 @@
+package jwt
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+)
+
+var (
+	ErrNotEdPrivateKey = errors.New("Key is not a valid Ed25519 private key")
+	ErrNotEdPublicKey  = errors.New("Key is not a valid Ed25519 public key")
+)
+
+// Parse PEM-encoded Edwards curve private key
+func ParseEdPrivateKeyFromPEM(key []byte) (crypto.PrivateKey, error) {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		return nil, ErrKeyMustBePEMEncoded
+	}
+
+	// Parse the key
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+		return nil, err
+	}
+
+	var pkey ed25519.PrivateKey
+	var ok bool
+	if pkey, ok = parsedKey.(ed25519.PrivateKey); !ok {
+		return nil, ErrNotEdPrivateKey
+	}
+
+	return pkey, nil
+}
+
+// Parse PEM-encoded Edwards curve public key
+func ParseEdPublicKeyFromPEM(key []byte) (crypto.PublicKey, error) {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		return nil, ErrKeyMustBePEMEncoded
+	}
+
+	// Parse the key
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParsePKIXPublicKey(block.Bytes); err != nil {
+		return nil, err
+	}
+
+	var pkey ed25519.PublicKey
+	var ok bool
+	if pkey, ok = parsedKey.(ed25519.PublicKey); !ok {
+		return nil, ErrNotEdPublicKey
+	}
+
+	return pkey, nil
+}

--- a/vendor/github.com/golang-jwt/jwt/errors.go
+++ b/vendor/github.com/golang-jwt/jwt/errors.go
@@ -1,0 +1,59 @@
+package jwt
+
+import (
+	"errors"
+)
+
+// Error constants
+var (
+	ErrInvalidKey      = errors.New("key is invalid")
+	ErrInvalidKeyType  = errors.New("key is of invalid type")
+	ErrHashUnavailable = errors.New("the requested hash function is unavailable")
+)
+
+// The errors that might occur when parsing and validating a token
+const (
+	ValidationErrorMalformed        uint32 = 1 << iota // Token is malformed
+	ValidationErrorUnverifiable                        // Token could not be verified because of signing problems
+	ValidationErrorSignatureInvalid                    // Signature validation failed
+
+	// Standard Claim validation errors
+	ValidationErrorAudience      // AUD validation failed
+	ValidationErrorExpired       // EXP validation failed
+	ValidationErrorIssuedAt      // IAT validation failed
+	ValidationErrorIssuer        // ISS validation failed
+	ValidationErrorNotValidYet   // NBF validation failed
+	ValidationErrorId            // JTI validation failed
+	ValidationErrorClaimsInvalid // Generic claims validation error
+)
+
+// Helper for constructing a ValidationError with a string error message
+func NewValidationError(errorText string, errorFlags uint32) *ValidationError {
+	return &ValidationError{
+		text:   errorText,
+		Errors: errorFlags,
+	}
+}
+
+// The error from Parse if token is not valid
+type ValidationError struct {
+	Inner  error  // stores the error returned by external dependencies, i.e.: KeyFunc
+	Errors uint32 // bitfield.  see ValidationError... constants
+	text   string // errors that do not have a valid error just have text
+}
+
+// Validation error is an error type
+func (e ValidationError) Error() string {
+	if e.Inner != nil {
+		return e.Inner.Error()
+	} else if e.text != "" {
+		return e.text
+	} else {
+		return "token is invalid"
+	}
+}
+
+// No errors
+func (e *ValidationError) valid() bool {
+	return e.Errors == 0
+}

--- a/vendor/github.com/golang-jwt/jwt/hmac.go
+++ b/vendor/github.com/golang-jwt/jwt/hmac.go
@@ -1,0 +1,95 @@
+package jwt
+
+import (
+	"crypto"
+	"crypto/hmac"
+	"errors"
+)
+
+// Implements the HMAC-SHA family of signing methods signing methods
+// Expects key type of []byte for both signing and validation
+type SigningMethodHMAC struct {
+	Name string
+	Hash crypto.Hash
+}
+
+// Specific instances for HS256 and company
+var (
+	SigningMethodHS256  *SigningMethodHMAC
+	SigningMethodHS384  *SigningMethodHMAC
+	SigningMethodHS512  *SigningMethodHMAC
+	ErrSignatureInvalid = errors.New("signature is invalid")
+)
+
+func init() {
+	// HS256
+	SigningMethodHS256 = &SigningMethodHMAC{"HS256", crypto.SHA256}
+	RegisterSigningMethod(SigningMethodHS256.Alg(), func() SigningMethod {
+		return SigningMethodHS256
+	})
+
+	// HS384
+	SigningMethodHS384 = &SigningMethodHMAC{"HS384", crypto.SHA384}
+	RegisterSigningMethod(SigningMethodHS384.Alg(), func() SigningMethod {
+		return SigningMethodHS384
+	})
+
+	// HS512
+	SigningMethodHS512 = &SigningMethodHMAC{"HS512", crypto.SHA512}
+	RegisterSigningMethod(SigningMethodHS512.Alg(), func() SigningMethod {
+		return SigningMethodHS512
+	})
+}
+
+func (m *SigningMethodHMAC) Alg() string {
+	return m.Name
+}
+
+// Verify the signature of HSXXX tokens.  Returns nil if the signature is valid.
+func (m *SigningMethodHMAC) Verify(signingString, signature string, key interface{}) error {
+	// Verify the key is the right type
+	keyBytes, ok := key.([]byte)
+	if !ok {
+		return ErrInvalidKeyType
+	}
+
+	// Decode signature, for comparison
+	sig, err := DecodeSegment(signature)
+	if err != nil {
+		return err
+	}
+
+	// Can we use the specified hashing method?
+	if !m.Hash.Available() {
+		return ErrHashUnavailable
+	}
+
+	// This signing method is symmetric, so we validate the signature
+	// by reproducing the signature from the signing string and key, then
+	// comparing that against the provided signature.
+	hasher := hmac.New(m.Hash.New, keyBytes)
+	hasher.Write([]byte(signingString))
+	if !hmac.Equal(sig, hasher.Sum(nil)) {
+		return ErrSignatureInvalid
+	}
+
+	// No validation errors.  Signature is good.
+	return nil
+}
+
+// Implements the Sign method from SigningMethod for this signing method.
+// Key must be []byte
+func (m *SigningMethodHMAC) Sign(signingString string, key interface{}) (string, error) {
+	if keyBytes, ok := key.([]byte); ok {
+		if !m.Hash.Available() {
+			return "", ErrHashUnavailable
+		}
+
+		hasher := hmac.New(m.Hash.New, keyBytes)
+		hasher.Write([]byte(signingString))
+
+		return EncodeSegment(hasher.Sum(nil)), nil
+	}
+
+	return "", ErrInvalidKeyType
+}

--- a/vendor/github.com/golang-jwt/jwt/map_claims.go
+++ b/vendor/github.com/golang-jwt/jwt/map_claims.go
@@ -1,0 +1,120 @@
+package jwt
+
+import (
+	"encoding/json"
+	"errors"
+	// "fmt"
+)
+
+// Claims type that uses the map[string]interface{} for JSON decoding
+// This is the default claims type if you don't supply one
+type MapClaims map[string]interface{}
+
+// VerifyAudience Compares the aud claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
+	var aud []string
+	switch v := m["aud"].(type) {
+	case string:
+		aud = append(aud, v)
+	case []string:
+		aud = v
+	case []interface{}:
+		for _, a := range v {
+			vs, ok := a.(string)
+			if !ok {
+				return false
+			}
+			aud = append(aud, vs)
+		}
+	}
+	return verifyAud(aud, cmp, req)
+}
+
+// Compares the exp claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyExpiresAt(cmp int64, req bool) bool {
+	exp, ok := m["exp"]
+	if !ok {
+		return !req
+	}
+	switch expType := exp.(type) {
+	case float64:
+		return verifyExp(int64(expType), cmp, req)
+	case json.Number:
+		v, _ := expType.Int64()
+		return verifyExp(v, cmp, req)
+	}
+	return false
+}
+
+// Compares the iat claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyIssuedAt(cmp int64, req bool) bool {
+	iat, ok := m["iat"]
+	if !ok {
+		return !req
+	}
+	switch iatType := iat.(type) {
+	case float64:
+		return verifyIat(int64(iatType), cmp, req)
+	case json.Number:
+		v, _ := iatType.Int64()
+		return verifyIat(v, cmp, req)
+	}
+	return false
+}
+
+// Compares the iss claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyIssuer(cmp string, req bool) bool {
+	iss, _ := m["iss"].(string)
+	return verifyIss(iss, cmp, req)
+}
+
+// Compares the nbf claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyNotBefore(cmp int64, req bool) bool {
+	nbf, ok := m["nbf"]
+	if !ok {
+		return !req
+	}
+	switch nbfType := nbf.(type) {
+	case float64:
+		return verifyNbf(int64(nbfType), cmp, req)
+	case json.Number:
+		v, _ := nbfType.Int64()
+		return verifyNbf(v, cmp, req)
+	}
+	return false
+}
+
+// Validates time based claims "exp, iat, nbf".
+// There is no accounting for clock skew.
+// As well, if any of the above claims are not in the token, it will still
+// be considered a valid claim.
+func (m MapClaims) Valid() error {
+	vErr := new(ValidationError)
+	now := TimeFunc().Unix()
+
+	if !m.VerifyExpiresAt(now, false) {
+		vErr.Inner = errors.New("Token is expired")
+		vErr.Errors |= ValidationErrorExpired
+	}
+
+	if !m.VerifyIssuedAt(now, false) {
+		vErr.Inner = errors.New("Token used before issued")
+		vErr.Errors |= ValidationErrorIssuedAt
+	}
+
+	if !m.VerifyNotBefore(now, false) {
+		vErr.Inner = errors.New("Token is not valid yet")
+		vErr.Errors |= ValidationErrorNotValidYet
+	}
+
+	if vErr.valid() {
+		return nil
+	}
+
+	return vErr
+}

--- a/vendor/github.com/golang-jwt/jwt/none.go
+++ b/vendor/github.com/golang-jwt/jwt/none.go
@@ -1,0 +1,52 @@
+package jwt
+
+// Implements the none signing method.  This is required by the spec
+// but you probably should never use it.
+var SigningMethodNone *signingMethodNone
+
+const UnsafeAllowNoneSignatureType unsafeNoneMagicConstant = "none signing method allowed"
+
+var NoneSignatureTypeDisallowedError error
+
+type signingMethodNone struct{}
+type unsafeNoneMagicConstant string
+
+func init() {
+	SigningMethodNone = &signingMethodNone{}
+	NoneSignatureTypeDisallowedError = NewValidationError("'none' signature type is not allowed", ValidationErrorSignatureInvalid)
+
+	RegisterSigningMethod(SigningMethodNone.Alg(), func() SigningMethod {
+		return SigningMethodNone
+	})
+}
+
+func (m *signingMethodNone) Alg() string {
+	return "none"
+}
+
+// Only allow 'none' alg type if UnsafeAllowNoneSignatureType is specified as the key
+func (m *signingMethodNone) Verify(signingString, signature string, key interface{}) (err error) {
+	// Key must be UnsafeAllowNoneSignatureType to prevent accidentally
+	// accepting 'none' signing method
+	if _, ok := key.(unsafeNoneMagicConstant); !ok {
+		return NoneSignatureTypeDisallowedError
+	}
+	// If signing method is none, signature must be an empty string
+	if signature != "" {
+		return NewValidationError(
+			"'none' signing method with non-empty signature",
+			ValidationErrorSignatureInvalid,
+		)
+	}
+
+	// Accept 'none' signing method.
+	return nil
+}
+
+// Only allow 'none' signing if UnsafeAllowNoneSignatureType is specified as the key
+func (m *signingMethodNone) Sign(signingString string, key interface{}) (string, error) {
+	if _, ok := key.(unsafeNoneMagicConstant); ok {
+		return "", nil
+	}
+	return "", NoneSignatureTypeDisallowedError
+}

--- a/vendor/github.com/golang-jwt/jwt/parser.go
+++ b/vendor/github.com/golang-jwt/jwt/parser.go
@@ -1,0 +1,148 @@
+package jwt
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type Parser struct {
+	ValidMethods         []string // If populated, only these methods will be considered valid
+	UseJSONNumber        bool     // Use JSON Number format in JSON decoder
+	SkipClaimsValidation bool     // Skip claims validation during token parsing
+}
+
+// Parse, validate, and return a token.
+// keyFunc will receive the parsed token and should return the key for validating.
+// If everything is kosher, err will be nil
+func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
+	return p.ParseWithClaims(tokenString, MapClaims{}, keyFunc)
+}
+
+func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
+	token, parts, err := p.ParseUnverified(tokenString, claims)
+	if err != nil {
+		return token, err
+	}
+
+	// Verify signing method is in the required set
+	if p.ValidMethods != nil {
+		var signingMethodValid = false
+		var alg = token.Method.Alg()
+		for _, m := range p.ValidMethods {
+			if m == alg {
+				signingMethodValid = true
+				break
+			}
+		}
+		if !signingMethodValid {
+			// signing method is not in the listed set
+			return token, NewValidationError(fmt.Sprintf("signing method %v is invalid", alg), ValidationErrorSignatureInvalid)
+		}
+	}
+
+	// Lookup key
+	var key interface{}
+	if keyFunc == nil {
+		// keyFunc was not provided.  short circuiting validation
+		return token, NewValidationError("no Keyfunc was provided.", ValidationErrorUnverifiable)
+	}
+	if key, err = keyFunc(token); err != nil {
+		// keyFunc returned an error
+		if ve, ok := err.(*ValidationError); ok {
+			return token, ve
+		}
+		return token, &ValidationError{Inner: err, Errors: ValidationErrorUnverifiable}
+	}
+
+	vErr := &ValidationError{}
+
+	// Validate Claims
+	if !p.SkipClaimsValidation {
+		if err := token.Claims.Valid(); err != nil {
+
+			// If the Claims Valid returned an error, check if it is a validation error,
+			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
+			if e, ok := err.(*ValidationError); !ok {
+				vErr = &ValidationError{Inner: err, Errors: ValidationErrorClaimsInvalid}
+			} else {
+				vErr = e
+			}
+		}
+	}
+
+	// Perform validation
+	token.Signature = parts[2]
+	if err = token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
+		vErr.Inner = err
+		vErr.Errors |= ValidationErrorSignatureInvalid
+	}
+
+	if vErr.valid() {
+		token.Valid = true
+		return token, nil
+	}
+
+	return token, vErr
+}
+
+// WARNING: Don't use this method unless you know what you're doing
+//
+// This method parses the token but doesn't validate the signature. It's only
+// ever useful in cases where you know the signature is valid (because it has
+// been checked previously in the stack) and you want to extract values from
+// it.
+func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Token, parts []string, err error) {
+	parts = strings.Split(tokenString, ".")
+	if len(parts) != 3 {
+		return nil, parts, NewValidationError("token contains an invalid number of segments", ValidationErrorMalformed)
+	}
+
+	token = &Token{Raw: tokenString}
+
+	// parse Header
+	var headerBytes []byte
+	if headerBytes, err = DecodeSegment(parts[0]); err != nil {
+		if strings.HasPrefix(strings.ToLower(tokenString), "bearer ") {
+			return token, parts, NewValidationError("tokenstring should not contain 'bearer '", ValidationErrorMalformed)
+		}
+		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	}
+	if err = json.Unmarshal(headerBytes, &token.Header); err != nil {
+		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	}
+
+	// parse Claims
+	var claimBytes []byte
+	token.Claims = claims
+
+	if claimBytes, err = DecodeSegment(parts[1]); err != nil {
+		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	}
+	dec := json.NewDecoder(bytes.NewBuffer(claimBytes))
+	if p.UseJSONNumber {
+		dec.UseNumber()
+	}
+	// JSON Decode.  Special case for map type to avoid weird pointer behavior
+	if c, ok := token.Claims.(MapClaims); ok {
+		err = dec.Decode(&c)
+	} else {
+		err = dec.Decode(&claims)
+	}
+	// Handle decode error
+	if err != nil {
+		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	}
+
+	// Lookup signature method
+	if method, ok := token.Header["alg"].(string); ok {
+		if token.Method = GetSigningMethod(method); token.Method == nil {
+			return token, parts, NewValidationError("signing method (alg) is unavailable.", ValidationErrorUnverifiable)
+		}
+	} else {
+		return token, parts, NewValidationError("signing method (alg) is unspecified.", ValidationErrorUnverifiable)
+	}
+
+	return token, parts, nil
+}

--- a/vendor/github.com/golang-jwt/jwt/rsa.go
+++ b/vendor/github.com/golang-jwt/jwt/rsa.go
@@ -1,0 +1,101 @@
+package jwt
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+// Implements the RSA family of signing methods signing methods
+// Expects *rsa.PrivateKey for signing and *rsa.PublicKey for validation
+type SigningMethodRSA struct {
+	Name string
+	Hash crypto.Hash
+}
+
+// Specific instances for RS256 and company
+var (
+	SigningMethodRS256 *SigningMethodRSA
+	SigningMethodRS384 *SigningMethodRSA
+	SigningMethodRS512 *SigningMethodRSA
+)
+
+func init() {
+	// RS256
+	SigningMethodRS256 = &SigningMethodRSA{"RS256", crypto.SHA256}
+	RegisterSigningMethod(SigningMethodRS256.Alg(), func() SigningMethod {
+		return SigningMethodRS256
+	})
+
+	// RS384
+	SigningMethodRS384 = &SigningMethodRSA{"RS384", crypto.SHA384}
+	RegisterSigningMethod(SigningMethodRS384.Alg(), func() SigningMethod {
+		return SigningMethodRS384
+	})
+
+	// RS512
+	SigningMethodRS512 = &SigningMethodRSA{"RS512", crypto.SHA512}
+	RegisterSigningMethod(SigningMethodRS512.Alg(), func() SigningMethod {
+		return SigningMethodRS512
+	})
+}
+
+func (m *SigningMethodRSA) Alg() string {
+	return m.Name
+}
+
+// Implements the Verify method from SigningMethod
+// For this signing method, must be an *rsa.PublicKey structure.
+func (m *SigningMethodRSA) Verify(signingString, signature string, key interface{}) error {
+	var err error
+
+	// Decode the signature
+	var sig []byte
+	if sig, err = DecodeSegment(signature); err != nil {
+		return err
+	}
+
+	var rsaKey *rsa.PublicKey
+	var ok bool
+
+	if rsaKey, ok = key.(*rsa.PublicKey); !ok {
+		return ErrInvalidKeyType
+	}
+
+	// Create hasher
+	if !m.Hash.Available() {
+		return ErrHashUnavailable
+	}
+	hasher := m.Hash.New()
+	hasher.Write([]byte(signingString))
+
+	// Verify the signature
+	return rsa.VerifyPKCS1v15(rsaKey, m.Hash, hasher.Sum(nil), sig)
+}
+
+// Implements the Sign method from SigningMethod
+// For this signing method, must be an *rsa.PrivateKey structure.
+func (m *SigningMethodRSA) Sign(signingString string, key interface{}) (string, error) {
+	var rsaKey *rsa.PrivateKey
+	var ok bool
+
+	// Validate type of key
+	if rsaKey, ok = key.(*rsa.PrivateKey); !ok {
+		return "", ErrInvalidKey
+	}
+
+	// Create the hasher
+	if !m.Hash.Available() {
+		return "", ErrHashUnavailable
+	}
+
+	hasher := m.Hash.New()
+	hasher.Write([]byte(signingString))
+
+	// Sign the string and return the encoded bytes
+	if sigBytes, err := rsa.SignPKCS1v15(rand.Reader, rsaKey, m.Hash, hasher.Sum(nil)); err == nil {
+		return EncodeSegment(sigBytes), nil
+	} else {
+		return "", err
+	}
+}

--- a/vendor/github.com/golang-jwt/jwt/rsa_pss.go
+++ b/vendor/github.com/golang-jwt/jwt/rsa_pss.go
@@ -1,0 +1,142 @@
+// +build go1.4
+
+package jwt
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+// Implements the RSAPSS family of signing methods signing methods
+type SigningMethodRSAPSS struct {
+	*SigningMethodRSA
+	Options *rsa.PSSOptions
+	// VerifyOptions is optional. If set overrides Options for rsa.VerifyPPS.
+	// Used to accept tokens signed with rsa.PSSSaltLengthAuto, what doesn't follow
+	// https://tools.ietf.org/html/rfc7518#section-3.5 but was used previously.
+	// See https://github.com/dgrijalva/jwt-go/issues/285#issuecomment-437451244 for details.
+	VerifyOptions *rsa.PSSOptions
+}
+
+// Specific instances for RS/PS and company.
+var (
+	SigningMethodPS256 *SigningMethodRSAPSS
+	SigningMethodPS384 *SigningMethodRSAPSS
+	SigningMethodPS512 *SigningMethodRSAPSS
+)
+
+func init() {
+	// PS256
+	SigningMethodPS256 = &SigningMethodRSAPSS{
+		SigningMethodRSA: &SigningMethodRSA{
+			Name: "PS256",
+			Hash: crypto.SHA256,
+		},
+		Options: &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthEqualsHash,
+		},
+		VerifyOptions: &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthAuto,
+		},
+	}
+	RegisterSigningMethod(SigningMethodPS256.Alg(), func() SigningMethod {
+		return SigningMethodPS256
+	})
+
+	// PS384
+	SigningMethodPS384 = &SigningMethodRSAPSS{
+		SigningMethodRSA: &SigningMethodRSA{
+			Name: "PS384",
+			Hash: crypto.SHA384,
+		},
+		Options: &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthEqualsHash,
+		},
+		VerifyOptions: &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthAuto,
+		},
+	}
+	RegisterSigningMethod(SigningMethodPS384.Alg(), func() SigningMethod {
+		return SigningMethodPS384
+	})
+
+	// PS512
+	SigningMethodPS512 = &SigningMethodRSAPSS{
+		SigningMethodRSA: &SigningMethodRSA{
+			Name: "PS512",
+			Hash: crypto.SHA512,
+		},
+		Options: &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthEqualsHash,
+		},
+		VerifyOptions: &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthAuto,
+		},
+	}
+	RegisterSigningMethod(SigningMethodPS512.Alg(), func() SigningMethod {
+		return SigningMethodPS512
+	})
+}
+
+// Implements the Verify method from SigningMethod
+// For this verify method, key must be an rsa.PublicKey struct
+func (m *SigningMethodRSAPSS) Verify(signingString, signature string, key interface{}) error {
+	var err error
+
+	// Decode the signature
+	var sig []byte
+	if sig, err = DecodeSegment(signature); err != nil {
+		return err
+	}
+
+	var rsaKey *rsa.PublicKey
+	switch k := key.(type) {
+	case *rsa.PublicKey:
+		rsaKey = k
+	default:
+		return ErrInvalidKey
+	}
+
+	// Create hasher
+	if !m.Hash.Available() {
+		return ErrHashUnavailable
+	}
+	hasher := m.Hash.New()
+	hasher.Write([]byte(signingString))
+
+	opts := m.Options
+	if m.VerifyOptions != nil {
+		opts = m.VerifyOptions
+	}
+
+	return rsa.VerifyPSS(rsaKey, m.Hash, hasher.Sum(nil), sig, opts)
+}
+
+// Implements the Sign method from SigningMethod
+// For this signing method, key must be an rsa.PrivateKey struct
+func (m *SigningMethodRSAPSS) Sign(signingString string, key interface{}) (string, error) {
+	var rsaKey *rsa.PrivateKey
+
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		rsaKey = k
+	default:
+		return "", ErrInvalidKeyType
+	}
+
+	// Create the hasher
+	if !m.Hash.Available() {
+		return "", ErrHashUnavailable
+	}
+
+	hasher := m.Hash.New()
+	hasher.Write([]byte(signingString))
+
+	// Sign the string and return the encoded bytes
+	if sigBytes, err := rsa.SignPSS(rand.Reader, rsaKey, m.Hash, hasher.Sum(nil), m.Options); err == nil {
+		return EncodeSegment(sigBytes), nil
+	} else {
+		return "", err
+	}
+}

--- a/vendor/github.com/golang-jwt/jwt/rsa_utils.go
+++ b/vendor/github.com/golang-jwt/jwt/rsa_utils.go
@@ -1,0 +1,101 @@
+package jwt
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+)
+
+var (
+	ErrKeyMustBePEMEncoded = errors.New("Invalid Key: Key must be a PEM encoded PKCS1 or PKCS8 key")
+	ErrNotRSAPrivateKey    = errors.New("Key is not a valid RSA private key")
+	ErrNotRSAPublicKey     = errors.New("Key is not a valid RSA public key")
+)
+
+// Parse PEM encoded PKCS1 or PKCS8 private key
+func ParseRSAPrivateKeyFromPEM(key []byte) (*rsa.PrivateKey, error) {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		return nil, ErrKeyMustBePEMEncoded
+	}
+
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
+		if parsedKey, err = x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+			return nil, err
+		}
+	}
+
+	var pkey *rsa.PrivateKey
+	var ok bool
+	if pkey, ok = parsedKey.(*rsa.PrivateKey); !ok {
+		return nil, ErrNotRSAPrivateKey
+	}
+
+	return pkey, nil
+}
+
+// Parse PEM encoded PKCS1 or PKCS8 private key protected with password
+func ParseRSAPrivateKeyFromPEMWithPassword(key []byte, password string) (*rsa.PrivateKey, error) {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		return nil, ErrKeyMustBePEMEncoded
+	}
+
+	var parsedKey interface{}
+
+	var blockDecrypted []byte
+	if blockDecrypted, err = x509.DecryptPEMBlock(block, []byte(password)); err != nil {
+		return nil, err
+	}
+
+	if parsedKey, err = x509.ParsePKCS1PrivateKey(blockDecrypted); err != nil {
+		if parsedKey, err = x509.ParsePKCS8PrivateKey(blockDecrypted); err != nil {
+			return nil, err
+		}
+	}
+
+	var pkey *rsa.PrivateKey
+	var ok bool
+	if pkey, ok = parsedKey.(*rsa.PrivateKey); !ok {
+		return nil, ErrNotRSAPrivateKey
+	}
+
+	return pkey, nil
+}
+
+// Parse PEM encoded PKCS1 or PKCS8 public key
+func ParseRSAPublicKeyFromPEM(key []byte) (*rsa.PublicKey, error) {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		return nil, ErrKeyMustBePEMEncoded
+	}
+
+	// Parse the key
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParsePKIXPublicKey(block.Bytes); err != nil {
+		if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+			parsedKey = cert.PublicKey
+		} else {
+			return nil, err
+		}
+	}
+
+	var pkey *rsa.PublicKey
+	var ok bool
+	if pkey, ok = parsedKey.(*rsa.PublicKey); !ok {
+		return nil, ErrNotRSAPublicKey
+	}
+
+	return pkey, nil
+}

--- a/vendor/github.com/golang-jwt/jwt/signing_method.go
+++ b/vendor/github.com/golang-jwt/jwt/signing_method.go
@@ -1,0 +1,35 @@
+package jwt
+
+import (
+	"sync"
+)
+
+var signingMethods = map[string]func() SigningMethod{}
+var signingMethodLock = new(sync.RWMutex)
+
+// Implement SigningMethod to add new methods for signing or verifying tokens.
+type SigningMethod interface {
+	Verify(signingString, signature string, key interface{}) error // Returns nil if signature is valid
+	Sign(signingString string, key interface{}) (string, error)    // Returns encoded signature or error
+	Alg() string                                                   // returns the alg identifier for this method (example: 'HS256')
+}
+
+// Register the "alg" name and a factory function for signing method.
+// This is typically done during init() in the method's implementation
+func RegisterSigningMethod(alg string, f func() SigningMethod) {
+	signingMethodLock.Lock()
+	defer signingMethodLock.Unlock()
+
+	signingMethods[alg] = f
+}
+
+// Get a signing method from an "alg" string
+func GetSigningMethod(alg string) (method SigningMethod) {
+	signingMethodLock.RLock()
+	defer signingMethodLock.RUnlock()
+
+	if methodF, ok := signingMethods[alg]; ok {
+		method = methodF()
+	}
+	return
+}

--- a/vendor/github.com/golang-jwt/jwt/token.go
+++ b/vendor/github.com/golang-jwt/jwt/token.go
@@ -1,0 +1,104 @@
+package jwt
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// TimeFunc provides the current time when parsing token to validate "exp" claim (expiration time).
+// You can override it to use another time value.  This is useful for testing or if your
+// server uses a different time zone than your tokens.
+var TimeFunc = time.Now
+
+// Parse methods use this callback function to supply
+// the key for verification.  The function receives the parsed,
+// but unverified Token.  This allows you to use properties in the
+// Header of the token (such as `kid`) to identify which key to use.
+type Keyfunc func(*Token) (interface{}, error)
+
+// A JWT Token.  Different fields will be used depending on whether you're
+// creating or parsing/verifying a token.
+type Token struct {
+	Raw       string                 // The raw token.  Populated when you Parse a token
+	Method    SigningMethod          // The signing method used or to be used
+	Header    map[string]interface{} // The first segment of the token
+	Claims    Claims                 // The second segment of the token
+	Signature string                 // The third segment of the token.  Populated when you Parse a token
+	Valid     bool                   // Is the token valid?  Populated when you Parse/Verify a token
+}
+
+// Create a new Token.  Takes a signing method
+func New(method SigningMethod) *Token {
+	return NewWithClaims(method, MapClaims{})
+}
+
+func NewWithClaims(method SigningMethod, claims Claims) *Token {
+	return &Token{
+		Header: map[string]interface{}{
+			"typ": "JWT",
+			"alg": method.Alg(),
+		},
+		Claims: claims,
+		Method: method,
+	}
+}
+
+// Get the complete, signed token
+func (t *Token) SignedString(key interface{}) (string, error) {
+	var sig, sstr string
+	var err error
+	if sstr, err = t.SigningString(); err != nil {
+		return "", err
+	}
+	if sig, err = t.Method.Sign(sstr, key); err != nil {
+		return "", err
+	}
+	return strings.Join([]string{sstr, sig}, "."), nil
+}
+
+// Generate the signing string.  This is the
+// most expensive part of the whole deal.  Unless you
+// need this for something special, just go straight for
+// the SignedString.
+func (t *Token) SigningString() (string, error) {
+	var err error
+	parts := make([]string, 2)
+	for i := range parts {
+		var jsonValue []byte
+		if i == 0 {
+			if jsonValue, err = json.Marshal(t.Header); err != nil {
+				return "", err
+			}
+		} else {
+			if jsonValue, err = json.Marshal(t.Claims); err != nil {
+				return "", err
+			}
+		}
+
+		parts[i] = EncodeSegment(jsonValue)
+	}
+	return strings.Join(parts, "."), nil
+}
+
+// Parse, validate, and return a token.
+// keyFunc will receive the parsed token and should return the key for validating.
+// If everything is kosher, err will be nil
+func Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
+	return new(Parser).Parse(tokenString, keyFunc)
+}
+
+func ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
+	return new(Parser).ParseWithClaims(tokenString, claims, keyFunc)
+}
+
+// Encode JWT specific base64url encoding with padding stripped
+func EncodeSegment(seg []byte) string {
+	return base64.RawURLEncoding.EncodeToString(seg)
+}
+
+// Decode JWT specific base64url encoding with padding stripped
+func DecodeSegment(seg string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(seg)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -148,6 +148,9 @@ github.com/go-task/slim-sprig
 ## explicit; go 1.15
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
+# github.com/golang-jwt/jwt v3.2.2+incompatible
+## explicit
+github.com/golang-jwt/jwt
 # github.com/golang-jwt/jwt/v4 v4.2.0
 ## explicit; go 1.15
 github.com/golang-jwt/jwt/v4


### PR DESCRIPTION
Currently user has to create 3P apps to configure guard to able to get groups of the logged in user and do checkaccess as well.

With the support of the obo service in ARC, user will not need to create these 3P apps. This PR contains changes to call the obo service when the authnMode is set to "arc".
Token provider used : MSI token provider
In authorization if client id and client secret are not set we will use msi token to send checkaccess call