### PR TITLE
Add access token cnf public key validation in PoP token verifier

### DIFF
--- a/auth/providers/azure/pop_tokenverifier.go
+++ b/auth/providers/azure/pop_tokenverifier.go
@@ -165,7 +165,7 @@ func (p *PoPTokenVerifier) ValidatePopToken(token string) (string, error) {
 	var at string
 	if atClaim, ok := claims["at"]; ok {
 		if at, ok = atClaim.(string); !ok {
-			return "", errors.Errorf("Invalid token. at claim should be string")
+			return "", errors.Errorf("Invalid token. 'at' claim should be string")
 		}
 	} else {
 		return "", errors.Errorf("Invalid token. access token missing")

--- a/auth/providers/azure/pop_tokenverifier.go
+++ b/auth/providers/azure/pop_tokenverifier.go
@@ -222,7 +222,7 @@ func (p *PoPTokenVerifier) verifyAccessTokenClaims(publicKey jwk, accessToken st
 		return fmt.Errorf("could not parse access token in PoP token: %w", err)
 	}
 
-	// Get claims
+	// Get claims (don't verify signature since that's done by a separate verifier later)
 	var claims Claims
 	err = accessTokenJwt.UnsafeClaimsWithoutVerification(&claims)
 	if err != nil {

--- a/auth/providers/azure/pop_tokenverifier.go
+++ b/auth/providers/azure/pop_tokenverifier.go
@@ -168,7 +168,7 @@ func (p *PoPTokenVerifier) ValidatePopToken(token string) (string, error) {
 			return "", errors.Errorf("Invalid token. at claim should be string")
 		}
 	} else {
-		return "", errors.Errorf("Invlaid token. access token missing")
+		return "", errors.Errorf("Invalid token. access token missing")
 	}
 	if err = p.verifyAccessTokenClaims(jwk, at); err != nil {
 		return "", err

--- a/auth/providers/azure/pop_tokenverifier.go
+++ b/auth/providers/azure/pop_tokenverifier.go
@@ -232,7 +232,7 @@ func (p *PoPTokenVerifier) verifyAccessTokenClaims(publicKey jwk, accessToken st
 	// Get CNF (confirmation) claim
 	cnf, ok := claims["cnf"]
 	if !ok {
-		return errors.New("could not retrieve cnf claim from access token")
+		return errors.New("could not retrieve 'cnf' claim from access token")
 	}
 	cnfMap := map[string]string{}
 	if err := marshalGenericTo(cnf, &cnfMap); err != nil {

--- a/auth/providers/azure/pop_tokenverifier.go
+++ b/auth/providers/azure/pop_tokenverifier.go
@@ -236,7 +236,7 @@ func (p *PoPTokenVerifier) verifyAccessTokenClaims(publicKey jwk, accessToken st
 	}
 	cnfMap := map[string]string{}
 	if err := marshalGenericTo(cnf, &cnfMap); err != nil {
-		return fmt.Errorf("failed while parsing cnf in access token: %w", err)
+		return fmt.Errorf("failed while parsing 'cnf' in access token: %w", err)
 	}
 
 	// Build the expected public key data

--- a/auth/providers/azure/pop_tokenverifier.go
+++ b/auth/providers/azure/pop_tokenverifier.go
@@ -245,7 +245,7 @@ func (p *PoPTokenVerifier) verifyAccessTokenClaims(publicKey jwk, accessToken st
 	encodedJwt := base64.RawURLEncoding.EncodeToString(jwkS256[:])
 
 	if encodedJwt != cnfMap["kid"] {
-		return fmt.Errorf("PoP token validate failed: cnf claim mismatch")
+		return fmt.Errorf("PoP token validate failed: 'cnf' claim mismatch")
 	}
 	return nil
 }

--- a/auth/providers/azure/pop_tokenverifier_test.go
+++ b/auth/providers/azure/pop_tokenverifier_test.go
@@ -293,9 +293,9 @@ func TestPopTokenVerifier_Verify(t *testing.T) {
 
 	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", atCnfClaimMissing)
 	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "could not retrieve cnf claim from access token")
+	assert.EqualError(t, err, "could not retrieve 'cnf' claim from access token")
 
 	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", atCnfClaimWrong)
 	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "PoP token validate failed: cnf claim mismatch")
+	assert.EqualError(t, err, "PoP token validate failed: 'cnf' claim mismatch")
 }

--- a/auth/providers/azure/pop_tokenverifier_test.go
+++ b/auth/providers/azure/pop_tokenverifier_test.go
@@ -34,7 +34,8 @@ import (
 )
 
 const (
-	popAccessToken = `{ "aud": "client", "iss" : "kd", "exp" : "%d","cnf": {"kid":"%s","xms_ksl":"sw"} }`
+	popAccessToken           = `{ "aud": "client", "iss" : "kd", "exp" : "%d","cnf": {"kid":"%s","xms_ksl":"sw"} }`
+	popAccessTokenWithoutCnf = `{ "aud": "client", "iss" : "kd", "exp" : "%d" }`
 )
 
 type swPoPKey struct {
@@ -144,6 +145,8 @@ const (
 	tsClaimsMissing     = "tsClaimsMissing"
 	cnfClaimsMissing    = "cnfClaimsMissing"
 	cnfJwkClaimsWrong   = "cnfJwkClaimsWrong"
+	atCnfClaimMissing   = "atCnfClaimMissing"
+	atCnfClaimWrong     = "atCnfClaimWrong"
 )
 
 func GeneratePoPToken(ts int64, hostName, kid string) (string, error) {
@@ -160,12 +163,21 @@ func GeneratePoPToken(ts int64, hostName, kid string) (string, error) {
 		return "", fmt.Errorf("Failed to generate SF key. Error:%+v", err)
 	}
 
-	var cnf string = kid
-	if cnf == "" {
+	var cnf string
+	if kid == atCnfClaimWrong {
+		cnf = "wrongCnf"
+	} else {
 		cnf = popKey.KeyID()
 	}
 
-	at, err := key.GenerateToken([]byte(fmt.Sprintf(popAccessToken, time.Now().Add(time.Minute*5).Unix(), cnf)))
+	var accessTokenData string
+	if kid == atCnfClaimMissing {
+		accessTokenData = fmt.Sprintf(popAccessTokenWithoutCnf, time.Now().Add(time.Minute*5).Unix())
+	} else {
+		accessTokenData = fmt.Sprintf(popAccessToken, time.Now().Add(time.Minute*5).Unix(), cnf)
+	}
+
+	at, err := key.GenerateToken([]byte(accessTokenData))
 	if err != nil {
 		return "", fmt.Errorf("Error when generating token. Error:%+v", err)
 	}
@@ -206,7 +218,7 @@ func GeneratePoPToken(ts int64, hostName, kid string) (string, error) {
 		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "cnf":{"jwk":%s}, "nonce":"%s"}`, at, ts, popKey.Jwk(), nonce)
 	}
 	if kid == cnfClaimsMissing {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s"`, at, ts, hostName)
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "nonce": "%s"}`, at, ts, hostName, nonce)
 	}
 	if kid == cnfJwkClaimsWrong {
 		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{}, "nonce":"%s"}`, at, ts, hostName, nonce)
@@ -270,4 +282,20 @@ func TestPopTokenVerifier_Verify(t *testing.T) {
 	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", uClaimsMissing)
 	_, err = verifier.ValidatePopToken(invalidToken)
 	assert.EqualError(t, err, "Invalid token. 'u' claim is missing")
+
+	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", cnfClaimsMissing)
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Invalid token. 'cnf' claim is missing")
+
+	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", cnfJwkClaimsWrong)
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Invalid token. 'jwk' claim is empty")
+
+	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", atCnfClaimMissing)
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "could not retrieve cnf claim from access token")
+
+	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", atCnfClaimWrong)
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "PoP token validate failed: cnf claim mismatch")
 }


### PR DESCRIPTION
This check ensures that the user who requested the access token is the same user who created the PoP token.

Also added a few missed error cases and tests to the PoP token verifier.