### PR TITLE
Fix expiration pop token duration option

### DIFF
--- a/auth/providers/azure/options.go
+++ b/auth/providers/azure/options.go
@@ -74,7 +74,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.AKSTokenURL, "azure.aks-token-url", "", "url to call for AKS OBO flow")
 	fs.StringVar(&o.POPTokenHostname, "azure.pop-hostname", "", "hostname used to run the pop hostname verification; 'u' claim")
 	fs.BoolVar(&o.EnablePOP, "azure.enable-pop", false, "Enabling pop token verification")
-	fs.DurationVar(&o.PoPTokenValidityDuration, "azure.pop-token-validity-duration", 15, "time duration for PoP token to be considered valid from creation time, default 15 min")
+	fs.DurationVar(&o.PoPTokenValidityDuration, "azure.pop-token-validity-duration", 15*time.Minute, "time duration for PoP token to be considered valid from creation time, default 15 min")
 	fs.BoolVar(&o.ResolveGroupMembershipOnlyOnOverageClaim, "azure.graph-call-on-overage-claim", o.ResolveGroupMembershipOnlyOnOverageClaim, "set to true to resolve group membership only when overage claim is present. setting to false will always call graph api to resolve group membership")
 	fs.BoolVar(&o.VerifyClientID, "azure.verify-clientID", o.VerifyClientID, "set to true to validate token's audience claim matches clientID")
 	fs.BoolVar(&o.SkipGroupMembershipResolution, "azure.skip-group-membership-resolution", false, "when set to true, this will bypass getting group membership from graph api")

--- a/auth/providers/azure/pop_tokenverifier.go
+++ b/auth/providers/azure/pop_tokenverifier.go
@@ -112,7 +112,7 @@ func (p *PoPTokenVerifier) ValidatePopToken(token string) (string, error) {
 	var issuedTime time.Time
 	if ts, ok := claims["ts"]; ok {
 		convertTime(ts, &issuedTime)
-		expireat := issuedTime.Add(p.PoPTokenValidityDuration * time.Minute)
+		expireat := issuedTime.Add(p.PoPTokenValidityDuration)
 		if expireat.Before(now) {
 			return "", errors.Errorf("Token is expired. Now: %v, Valid till: %v", now, expireat)
 		}

--- a/auth/providers/azure/pop_tokenverifier_test.go
+++ b/auth/providers/azure/pop_tokenverifier_test.go
@@ -270,6 +270,7 @@ func TestPopTokenVerifier_Verify(t *testing.T) {
 	expiredToken, _ := GeneratePoPToken(time.Now().Add(time.Minute*-20).Unix(), "", "")
 	_, err = verifier.ValidatePopToken(expiredToken)
 	assert.NotNilf(t, err, "PoP verification succeed.")
+	assert.Containsf(t, err.Error(), "Token is expired", "Error message is not as expected")
 
 	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", tsClaimsMissing)
 	_, err = verifier.ValidatePopToken(invalidToken)


### PR DESCRIPTION
Currently conversion `PoPTokenValidityDuration` is not acting as expected. 

When passing a duration such as `15m` current code was multiplying `15m` (900000000000) with `time.Minute` (60000000000) with was causing very high expiration date non expected.

This fix assumes options are set using a proper time.Duration and respect it down to the pop token verification with any conversion in between.