### PR TITLE
Refactor and improve UT for PoP token verifier 

### DIFF
--- a/auth/providers/azure/pop_tokenverifier_test.go
+++ b/auth/providers/azure/pop_tokenverifier_test.go
@@ -14,460 +14,209 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package azure
+package azure_test
 
 import (
-	"crypto"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
-	"math/big"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"go.kubeguard.dev/guard/auth/providers/azure"
+
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/square/go-jose.v2"
 )
-
-const (
-	popAccessToken           = `{ "aud": "client", "iss" : "kd", "exp" : "%d","cnf": {"kid":"%s","xms_ksl":"sw"} }`
-	popAccessTokenWithoutCnf = `{ "aud": "client", "iss" : "kd", "exp" : "%d" }`
-)
-
-type swPoPKey struct {
-	key    *rsa.PrivateKey
-	keyID  string
-	jwk    string
-	jwkTP  string
-	reqCnf string
-}
-
-func (swk *swPoPKey) Alg() string {
-	return "RS256"
-}
-
-func (swk *swPoPKey) Sign(payload []byte) ([]byte, error) {
-	return swk.key.Sign(rand.Reader, payload, crypto.SHA256)
-}
-
-func (swk *swPoPKey) KeyID() string {
-	return swk.keyID
-}
-
-func (swk *swPoPKey) Cnf() string {
-	return swk.reqCnf
-}
-
-func (swk *swPoPKey) Jwk() string {
-	return swk.jwk
-}
-
-func NewSWPoPKey() (*swPoPKey, error) {
-	pop := &swPoPKey{}
-	rsa, err := rsa.GenerateKey(rand.Reader, 1028)
-	if err != nil {
-		return nil, err
-	}
-	pop.key = rsa
-	pubKey := rsa.PublicKey
-	e := big.NewInt(int64(pubKey.E))
-	eB64 := base64.RawURLEncoding.EncodeToString(e.Bytes())
-	n := pubKey.N
-	nB64 := base64.RawURLEncoding.EncodeToString(n.Bytes())
-	jwk := fmt.Sprintf(`{"e":"%s","kty":"RSA","n":"%s"}`, eB64, nB64)
-	jwkS256 := sha256.Sum256([]byte(jwk))
-	pop.jwkTP = base64.RawURLEncoding.EncodeToString(jwkS256[:])
-
-	reqCnfJSON := fmt.Sprintf(`{"kid":"%s","xms_ksl":"sw"}`, pop.jwkTP)
-	pop.reqCnf = base64.RawURLEncoding.EncodeToString([]byte(reqCnfJSON))
-	pop.keyID = pop.jwkTP
-	pop.jwk = fmt.Sprintf(`{"e":"%s","kty":"RSA","n":"%s","alg":"RS256","kid":"%s"}`, eB64, nB64, pop.keyID)
-
-	return pop, nil
-}
-
-type swKey struct {
-	keyID  string
-	pKey   *rsa.PrivateKey
-	pubKey interface{}
-}
-
-func (swk *swKey) Alg() string {
-	return "RS256"
-}
-
-func (swk *swKey) KeyID() string {
-	return ""
-}
-
-func NewSwkKey() (*swKey, error) {
-	rsa, err := rsa.GenerateKey(rand.Reader, 1028)
-	if err != nil {
-		return nil, err
-	}
-	return &swKey{"", rsa, rsa.Public()}, nil
-}
-
-func (swk *swKey) GenerateToken(payload []byte) (string, error) {
-	pKey := &jose.JSONWebKey{Key: swk.pKey, Algorithm: swk.Alg(), KeyID: swk.KeyID()}
-
-	// create a Square.jose RSA signer, used to sign the JWT
-	signerOpts := jose.SignerOptions{}
-	signerOpts.WithType("JWT")
-	rsaSigner, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pKey}, &signerOpts)
-	if err != nil {
-		return "", err
-	}
-	jws, err := rsaSigner.Sign(payload)
-	if err != nil {
-		return "", err
-	}
-
-	token, err := jws.CompactSerialize()
-	if err != nil {
-		return "", err
-	}
-	return token, nil
-}
-
-const (
-	badTokenKey         = "badToken"
-	headerBadKeyID      = "headerBadKeyID"
-	headerBadAlgo       = "headerBadAlgo"
-	headerBadtyp        = "headerBadtyp"
-	headerBadtypType    = "headerBadtypType"
-	headerBadtypMissing = "headerBadtypMissing"
-	uClaimsMissing      = "uClaimsMissing"
-	tsClaimsMissing     = "tsClaimsMissing"
-	atClaimsMissing     = "atClaimsMissing"
-	atClaimIncorrect    = "atClaimIncorrect"
-	cnfClaimsMissing    = "cnfClaimsMissing"
-	cnfJwkClaimsEmpty   = "cnfJwkClaimsEmpty"
-	cnfJwkClaimsWrong   = "cnfJwkClaimsWrong"
-	cnfJwkClaimsMissing = "cnfJwkClaimsMissing"
-	accessTokenCnfWrong = "accessTokenCnfWrong"
-	atClaimsWrongType   = "atClaimsWrongType"
-	atCnfClaimMissing   = "atCnfClaimMissing"
-	atCnfClaimWrong     = "atCnfClaimWrong"
-	tsClaimsTypeString  = "tsClaimsTypeString"
-	tsClaimsTypeUnknown = "tsClaimsTypeUnknown"
-	uClaimsWrongType    = "uClaimsWrongType"
-	signatureWrongType  = "signatureWrongType"
-)
-
-// A struct that represents a PoP token
-type PoPToken struct {
-	Header    string
-	Payload   string
-	Signature string
-}
-
-// A concrete builder struct that implements the steps to build a PoP token
-type PoPTokenBuilderImpl struct {
-	popKey   *swPoPKey
-	swkKey   *swKey
-	ts       int64
-	hostName string
-	kid      string // used for testing purposes
-	token    PoPToken
-}
-
-// A constructor function that returns a new PoPTokenBuilderImpl
-func NewPoPTokenBuilder() *PoPTokenBuilderImpl {
-	return &PoPTokenBuilderImpl{}
-}
-
-func (b *PoPTokenBuilderImpl) SetTimestamp(ts int64) *PoPTokenBuilderImpl {
-	b.ts = ts
-	return b
-}
-
-func (b *PoPTokenBuilderImpl) SetKid(kid string) *PoPTokenBuilderImpl {
-	b.kid = kid
-	return b
-}
-
-func (b *PoPTokenBuilderImpl) SetHostName(hostName string) *PoPTokenBuilderImpl {
-	b.hostName = hostName
-	return b
-}
-
-// A method that sets the header of the PoP token
-func (b *PoPTokenBuilderImpl) SetHeader() error {
-	keyID := b.popKey.KeyID()
-	algo := b.popKey.Alg()
-	typ := "pop"
-	if b.kid == headerBadKeyID {
-		keyID = ""
-	}
-	if b.kid == headerBadAlgo {
-		algo = "wrong"
-	}
-	if b.kid == headerBadtyp {
-		typ = "wrong"
-	}
-	header := fmt.Sprintf(`{"typ":"%s","alg":"%s","kid":"%s"}`, typ, algo, keyID)
-
-	if b.kid == headerBadtypType {
-		wrongTyp := 1
-		header = fmt.Sprintf(`{"typ":%d,"alg":"%s","kid":"%s"}`, wrongTyp, algo, keyID)
-	}
-	if b.kid == headerBadtypMissing {
-		header = fmt.Sprintf(`{"alg":"%s","kid":"%s"}`, algo, keyID)
-	}
-	b.token.Header = base64.RawURLEncoding.EncodeToString([]byte(header))
-	return nil
-}
-
-// A method that sets the payload of the PoP token
-func (b *PoPTokenBuilderImpl) SetPayload() error {
-	var cnf string
-	if b.kid == atCnfClaimWrong {
-		cnf = "wrongCnf"
-	} else {
-		cnf = b.popKey.KeyID()
-	}
-
-	nonce := uuid.New().String()
-	nonce = strings.Replace(nonce, "-", "", -1)
-
-	accessTokenData := fmt.Sprintf(popAccessToken, time.Now().Add(time.Minute*5).Unix(), cnf)
-	if b.kid == atCnfClaimMissing {
-		accessTokenData = fmt.Sprintf(popAccessTokenWithoutCnf, time.Now().Add(time.Minute*5).Unix())
-	}
-	if b.kid == accessTokenCnfWrong {
-		accessTokenData = fmt.Sprintf(`{ "aud": "client", "iss" : "kd", "exp" : "%d","cnf": {"kid":1} }`, time.Now().Add(time.Minute*5).Unix())
-	}
-
-	at, err := b.swkKey.GenerateToken([]byte(accessTokenData))
-	if err != nil {
-		return fmt.Errorf("Error when generating token. Error:%+v", err)
-	}
-
-	payload := fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, b.ts, b.hostName, b.popKey.Jwk(), nonce)
-	if b.kid == tsClaimsMissing {
-		payload = fmt.Sprintf(`{ "at" : "%s", "u": "%d", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, 1, b.popKey.Jwk(), nonce)
-	}
-	if b.kid == uClaimsMissing {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "cnf":{"jwk":%s}, "nonce":"%s"}`, at, b.ts, b.popKey.Jwk(), nonce)
-	}
-	if b.kid == cnfJwkClaimsEmpty {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{}, "nonce":"%s"}`, at, b.ts, b.hostName, nonce)
-	}
-	if b.kid == cnfJwkClaimsMissing {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":1, "nonce":"%s"}`, at, b.ts, b.hostName, nonce)
-	}
-	if b.kid == cnfJwkClaimsWrong {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{"jwk":1}, "nonce":"%s"}`, at, b.ts, b.hostName, nonce)
-	}
-	if b.kid == cnfClaimsMissing {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "nonce": "%s"}`, at, b.ts, b.hostName, nonce)
-	}
-	if b.kid == tsClaimsTypeString {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : "%s", "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, strconv.FormatInt(b.ts, 10), b.hostName, b.popKey.Jwk(), nonce)
-	}
-	if b.kid == tsClaimsTypeUnknown {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %t, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, bool(true), b.hostName, b.popKey.Jwk(), nonce)
-	}
-	if b.kid == atClaimsWrongType {
-		payload = fmt.Sprintf(`{ "at" : %d, "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, 12, b.ts, b.hostName, b.popKey.Jwk(), nonce)
-	}
-	if b.kid == uClaimsWrongType {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": %d, "cnf":{"jwk":%s}, "nonce":"%s"}`, at, b.ts, 1, b.popKey.Jwk(), nonce)
-	}
-	if b.kid == atClaimsMissing {
-		payload = fmt.Sprintf(`{ "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, b.ts, b.hostName, b.popKey.Jwk(), nonce)
-	}
-	if b.kid == atClaimIncorrect {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, fmt.Sprintf("%s.%s.%s", badTokenKey, badTokenKey, badTokenKey), b.ts, b.hostName, b.popKey.Jwk(), nonce)
-	}
-	b.token.Payload = base64.RawURLEncoding.EncodeToString([]byte(payload))
-	return nil
-}
-
-// A method that sets the signature of the PoP token
-func (b *PoPTokenBuilderImpl) SetSignature() error {
-	if b.kid == signatureWrongType {
-		b.token.Signature = "wrongSignature"
-		return nil
-	}
-	h256 := sha256.Sum256([]byte(b.token.Header + "." + b.token.Payload))
-	signature, err := b.popKey.Sign(h256[:])
-	if err != nil {
-		return fmt.Errorf("Error while signing pop key. Error:%+v", err)
-	}
-	b.token.Signature = base64.RawURLEncoding.EncodeToString(signature)
-	return nil
-}
-
-// A method that returns the final PoP token as a string
-func (b *PoPTokenBuilderImpl) GetToken() (string, error) {
-	var err error
-	b.popKey, err = NewSWPoPKey()
-	if err != nil {
-		return "", fmt.Errorf("Failed to generate Pop key. Error:%+v", err)
-	}
-	b.swkKey, err = NewSwkKey()
-	if err != nil {
-		return "", fmt.Errorf("Failed to generate SF key. Error:%+v", err)
-	}
-
-	if strings.Contains(b.kid, badTokenKey) {
-		return b.kid, nil
-	}
-
-	err = b.SetHeader()
-	if err != nil {
-		return "", err
-	}
-	err = b.SetPayload()
-	if err != nil {
-		return "", err
-	}
-	err = b.SetSignature()
-	if err != nil {
-		return "", err
-	}
-
-	finalToken := b.token.Header + "." + b.token.Payload + "." + b.token.Signature
-	return finalToken, nil
-}
 
 func TestPopTokenVerifier_Verify(t *testing.T) {
-	verifier := NewPoPVerifier("testHostname", 15*time.Minute)
+	verifier := azure.NewPoPVerifier("testHostname", 15*time.Minute)
 
-	validToken, _ := NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").GetToken()
-	_, err := verifier.ValidatePopToken(validToken)
-	assert.NoError(t, err)
+	// Test cases where no error is expected
+	noErrorTestCases := []struct {
+		desc string
+		kid  string
+	}{
+		{
+			desc: "happy path test case, all arguments are passed correctly",
+		},
+		{
+			desc: "'ts' claim is passed as string",
+			kid:  azure.TsClaimsTypeString,
+		},
+	}
+	for _, tC := range noErrorTestCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			validToken, _ := azure.NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(tC.kid).GetToken()
+			_, err := verifier.ValidatePopToken(validToken)
+			assert.NoError(t, err)
+		})
+	}
 
-	// 'ts' claim is passed as string
-	validToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(tsClaimsTypeString).GetToken()
-	_, err = verifier.ValidatePopToken(validToken)
-	assert.NoError(t, err)
+	// Test cases asserting "ErrorEquals"
+	testCases := []struct {
+		desc      string
+		kid       string
+		hostname  string
+		errString string
+	}{
+		{
+			desc:      "PoP token is not in the right format",
+			kid:       azure.BadTokenKey,
+			errString: "PoP token invalid schema. Token length: 1",
+		},
+		{
+			desc:      "PoP token is in the right format but is incorrect and could not be parsed",
+			kid:       fmt.Sprintf("%s.%s.%s", azure.BadTokenKey, azure.BadTokenKey, azure.BadTokenKey),
+			hostname:  "testHostname",
+			errString: "Could not parse PoP token. Error: invalid character 'm' looking for beginning of value",
+		},
+		{
+			desc:      "'keyID' claim in the header is missing",
+			kid:       azure.HeaderBadKeyID,
+			errString: "No KeyID found in PoP token header",
+		},
+		{
+			desc:      "'algo' claim in the header is incorrect",
+			kid:       azure.HeaderBadAlgo,
+			errString: "Wrong algorithm found in PoP token header, expected 'RS256' having 'wrong'",
+		},
+		{
+			desc:      "'typ' claim in the header is incorrect",
+			kid:       azure.HeaderBadtyp,
+			errString: "Wrong typ. Expected 'pop' having 'wrong'",
+		},
+		{
+			desc:      "'typ' claim is not present in the header",
+			kid:       azure.HeaderBadtypMissing,
+			errString: "Invalid token. 'typ' claim is missing",
+		},
+		{
+			desc:      "Invalid token. 'typ' claim should be of string",
+			kid:       azure.HeaderBadtypType,
+			hostname:  "testHostname",
+			errString: "Invalid token. 'typ' claim should be of string",
+		},
+		{
+			desc:      "'ts' claim is not present in the payload",
+			kid:       azure.TsClaimsMissing,
+			errString: "Invalid token. 'ts' claim is missing",
+		},
+		{
+			desc:      "Request and validation for the PoP token are running for different hostnames",
+			hostname:  "wrongHostnme",
+			errString: "Invalid Pop token due to host mismatch. Expected: \"testHostname\", received: \"wrongHostnme\"",
+		},
+		{
+			desc:      "'cnf' is not present in the access token",
+			kid:       azure.AtCnfClaimMissing,
+			hostname:  "testHostname",
+			errString: "could not retrieve 'cnf' claim from access token",
+		},
+		{
+			desc:      "'cnf' in the access token does not have the right value",
+			kid:       azure.AtCnfClaimWrong,
+			hostname:  "testHostname",
+			errString: "PoP token validate failed: 'cnf' claim mismatch",
+		},
+		{
+			desc:      "'cnf' claim in the payload is not present",
+			kid:       azure.CnfClaimsMissing,
+			hostname:  "testHostname",
+			errString: "Invalid token. 'cnf' claim is missing",
+		},
+		{
+			desc:      "'cnf' claim in the payload does not have 'jwk'",
+			kid:       azure.CnfJwkClaimsMissing,
+			hostname:  "testHostname",
+			errString: "Invalid token. 'cnf' claim is not in expected format",
+		},
+		{
+			desc:      "'jwk' in 'cnf' claim in the payload is empty",
+			kid:       azure.CnfJwkClaimsEmpty,
+			hostname:  "testHostname",
+			errString: "Invalid token. 'jwk' claim is empty",
+		},
+		{
+			desc:      "'u' claim is not present in the payload",
+			kid:       azure.UClaimsMissing,
+			hostname:  "testHostname",
+			errString: "Invalid token. 'u' claim is missing",
+		},
+		{
+			desc:      "'u' claim in the payload is not of string type",
+			kid:       azure.UClaimsWrongType,
+			hostname:  "testHostname",
+			errString: "Invalid token. 'u' claim should be of string",
+		},
+		{
+			desc:      "'at' claim in the payload is not of type string",
+			kid:       azure.AtClaimsWrongType,
+			hostname:  "testHostname",
+			errString: "Invalid token. 'at' claim should be string",
+		},
+		{
+			desc:      "'at' claim is not present in the payload",
+			kid:       azure.AtClaimsMissing,
+			hostname:  "testHostname",
+			errString: "Invalid token. access token missing",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			invalidToken, _ := azure.NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName(tC.hostname).SetKid(tC.kid).GetToken()
+			_, err := verifier.ValidatePopToken(invalidToken)
+			assert.EqualError(t, err, tC.errString)
+		})
+	}
 
-	// PoP token is not in the right format
-	invalidToken, _ := NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(badTokenKey).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "PoP token invalid schema. Token length: 1")
+	// Test cases asserting ErrorContains
+	testCasesContainsErrors := []struct {
+		desc      string
+		kid       string
+		ts        int64
+		hostname  string
+		errString string
+	}{
+		{
+			desc:      "'jwk' in the 'cnf' claim in the payload is not of string type",
+			kid:       azure.CnfJwkClaimsWrong,
+			errString: "failed while parsing 'jwk' claim in PoP token",
+		},
+		{
+			desc:      "'jwk' in the 'cnf' claim in the access token is not of string type",
+			kid:       azure.AccessTokenCnfWrong,
+			hostname:  "testHostname",
+			errString: "failed while parsing 'cnf' in access token",
+		},
+		{
+			desc:      "'at' claim value in they payload is not correct and could not be parsed",
+			kid:       azure.AtClaimIncorrect,
+			hostname:  "testHostname",
+			errString: "could not parse access token in PoP token",
+		},
+		{
+			desc:      "RSA verify error due to invalid signature in the PoP token",
+			kid:       azure.SignatureWrongType,
+			hostname:  "testHostname",
+			errString: "RSA verify err: crypto/rsa: verification error",
+		},
+	}
+	for _, tC := range testCasesContainsErrors {
+		t.Run(tC.desc, func(t *testing.T) {
+			invalidToken, _ := azure.NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(tC.kid).GetToken()
+			_, err := verifier.ValidatePopToken(invalidToken)
+			assert.ErrorContains(t, err, tC.errString)
+		})
+	}
 
-	// PoP token is in the right format but is incorrect and could not be parsed
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(fmt.Sprintf("%s.%s.%s", badTokenKey, badTokenKey, badTokenKey)).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Could not parse PoP token. Error: invalid character 'm' looking for beginning of value")
+	t.Run("'ts' has an expired timestamp", func(t *testing.T) {
+		expiredToken, _ := azure.NewPoPTokenBuilder().SetTimestamp(time.Now().Add(time.Minute * -20).Unix()).GetToken()
+		_, err := verifier.ValidatePopToken(expiredToken)
+		assert.NotNilf(t, err, "PoP verification succeed.")
+		assert.Containsf(t, err.Error(), "Token is expired", "Error message is not as expected")
+	})
 
-	// 'keyID' claim in the header is missing
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(headerBadKeyID).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "No KeyID found in PoP token header")
-
-	// 'algo' claim in the header is incorrect
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(headerBadAlgo).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Wrong algorithm found in PoP token header, expected 'RS256' having 'wrong'")
-
-	// 'typ' claim in the header is incorrect
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(headerBadtyp).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Wrong typ. Expected 'pop' having 'wrong'")
-
-	// 'typ' claim is not present in the header
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(headerBadtypMissing).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'typ' claim is missing")
-
-	// 'typ' claim in the header is not of string type
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(headerBadtypType).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'typ' claim should be of string")
-
-	// 'ts' has an expired timestamp
-	expiredToken, _ := NewPoPTokenBuilder().SetTimestamp(time.Now().Add(time.Minute * -20).Unix()).GetToken()
-	_, err = verifier.ValidatePopToken(expiredToken)
-	assert.NotNilf(t, err, "PoP verification succeed.")
-	assert.Containsf(t, err.Error(), "Token is expired", "Error message is not as expected")
-
-	// 'ts' claim is not present in the payload
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(tsClaimsMissing).GetToken() //(time.Now().Unix(), "", tsClaimsMissing)
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'ts' claim is missing")
-
-	// 'ts' claim in the payload is of unknown type and cannot be parsed. 'ts' is set to the default timestamp which has expired
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(tsClaimsTypeUnknown).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.Containsf(t, err.Error(), "Token is expired", "Error message is not as expected")
-
-	// Request and validation for the PoP token are running for different hostnames
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("wrongHostnme").GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid Pop token due to host mismatch. Expected: \"testHostname\", received: \"wrongHostnme\"")
-
-	// 'cnf' is not present in the access token
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(atCnfClaimMissing).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "could not retrieve 'cnf' claim from access token")
-
-	// 'cnf' in the access token does not have the right value
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(atCnfClaimWrong).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "PoP token validate failed: 'cnf' claim mismatch")
-
-	// 'cnf' claim in the payload is not present
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(cnfClaimsMissing).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'cnf' claim is missing")
-
-	// 'cnf' claim in the payload does not have 'jwk'
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(cnfJwkClaimsMissing).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'cnf' claim is not in expected format")
-
-	// 'jwk' in 'cnf' claim in the payload is empty
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(cnfJwkClaimsEmpty).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'jwk' claim is empty")
-
-	// 'jwk' in the 'cnf' claim in the payload is not of string type
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(cnfJwkClaimsWrong).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.ErrorContains(t, err, "failed while parsing 'jwk' claim in PoP token")
-
-	// 'jwk' in the 'cnf' claim in the access token is not of string type
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(accessTokenCnfWrong).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.ErrorContains(t, err, "failed while parsing 'cnf' in access token")
-
-	// 'u' claim is not present in the payload
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(uClaimsMissing).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'u' claim is missing")
-
-	// 'u' claim in the payload is not of string type
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(uClaimsWrongType).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'u' claim should be of string")
-
-	// 'at' claim in the payload is not of type string
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(atClaimsWrongType).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'at' claim should be string")
-
-	// 'at' claim is not present in the payload
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(atClaimsMissing).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. access token missing")
-
-	// 'at' claim value in they payload is not correct and could not be parsed
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(atClaimIncorrect).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.ErrorContains(t, err, "could not parse access token in PoP token")
-
-	// RSA verify error due to invalid signature in the PoP token
-	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(signatureWrongType).GetToken()
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.ErrorContains(t, err, "RSA verify err: crypto/rsa: verification error")
+	t.Run("'ts' claim in the payload is of unknown type and cannot be parsed. 'ts' is set to the default timestamp which has expired", func(t *testing.T) {
+		invalidToken, _ := azure.NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(azure.TsClaimsTypeUnknown).GetToken()
+		_, err := verifier.ValidatePopToken(invalidToken)
+		assert.Containsf(t, err.Error(), "Token is expired", "Error message is not as expected")
+	})
 }

--- a/auth/providers/azure/pop_tokenverifier_test.go
+++ b/auth/providers/azure/pop_tokenverifier_test.go
@@ -145,211 +145,329 @@ const (
 	uClaimsMissing      = "uClaimsMissing"
 	tsClaimsMissing     = "tsClaimsMissing"
 	atClaimsMissing     = "atClaimsMissing"
+	atClaimIncorrect    = "atClaimIncorrect"
 	cnfClaimsMissing    = "cnfClaimsMissing"
 	cnfJwkClaimsEmpty   = "cnfJwkClaimsEmpty"
 	cnfJwkClaimsWrong   = "cnfJwkClaimsWrong"
+	cnfJwkClaimsMissing = "cnfJwkClaimsMissing"
+	accessTokenCnfWrong = "accessTokenCnfWrong"
 	atClaimsWrongType   = "atClaimsWrongType"
 	atCnfClaimMissing   = "atCnfClaimMissing"
 	atCnfClaimWrong     = "atCnfClaimWrong"
 	tsClaimsTypeString  = "tsClaimsTypeString"
 	tsClaimsTypeUnknown = "tsClaimsTypeUnknown"
 	uClaimsWrongType    = "uClaimsWrongType"
+	signatureWrongType  = "signatureWrongType"
 )
 
-func GeneratePoPToken(ts int64, hostName, kid string) (string, error) {
-	if strings.Contains(kid, badTokenKey) {
-		return kid, nil
+// A struct that represents a PoP token
+type PoPToken struct {
+	Header    string
+	Payload   string
+	Signature string
+}
+
+// A concrete builder struct that implements the steps to build a PoP token
+type PoPTokenBuilderImpl struct {
+	popKey   *swPoPKey
+	swkKey   *swKey
+	ts       int64
+	hostName string
+	kid      string // used for testing purposes
+	token    PoPToken
+}
+
+// A constructor function that returns a new PoPTokenBuilderImpl
+func NewPoPTokenBuilder() *PoPTokenBuilderImpl {
+	return &PoPTokenBuilderImpl{}
+}
+
+func (b *PoPTokenBuilderImpl) SetTimestamp(ts int64) *PoPTokenBuilderImpl {
+	b.ts = ts
+	return b
+}
+
+func (b *PoPTokenBuilderImpl) SetKid(kid string) *PoPTokenBuilderImpl {
+	b.kid = kid
+	return b
+}
+
+func (b *PoPTokenBuilderImpl) SetHostName(hostName string) *PoPTokenBuilderImpl {
+	b.hostName = hostName
+	return b
+}
+
+// A method that sets the header of the PoP token
+func (b *PoPTokenBuilderImpl) SetHeader() error {
+	keyID := b.popKey.KeyID()
+	algo := b.popKey.Alg()
+	typ := "pop"
+	if b.kid == headerBadKeyID {
+		keyID = ""
 	}
-	popKey, err := NewSWPoPKey()
+	if b.kid == headerBadAlgo {
+		algo = "wrong"
+	}
+	if b.kid == headerBadtyp {
+		typ = "wrong"
+	}
+	header := fmt.Sprintf(`{"typ":"%s","alg":"%s","kid":"%s"}`, typ, algo, keyID)
+
+	if b.kid == headerBadtypType {
+		wrongTyp := 1
+		header = fmt.Sprintf(`{"typ":%d,"alg":"%s","kid":"%s"}`, wrongTyp, algo, keyID)
+	}
+	if b.kid == headerBadtypMissing {
+		header = fmt.Sprintf(`{"alg":"%s","kid":"%s"}`, algo, keyID)
+	}
+	b.token.Header = base64.RawURLEncoding.EncodeToString([]byte(header))
+	return nil
+}
+
+// A method that sets the payload of the PoP token
+func (b *PoPTokenBuilderImpl) SetPayload() error {
+	var cnf string
+	if b.kid == atCnfClaimWrong {
+		cnf = "wrongCnf"
+	} else {
+		cnf = b.popKey.KeyID()
+	}
+
+	nonce := uuid.New().String()
+	nonce = strings.Replace(nonce, "-", "", -1)
+
+	accessTokenData := fmt.Sprintf(popAccessToken, time.Now().Add(time.Minute*5).Unix(), cnf)
+	if b.kid == atCnfClaimMissing {
+		accessTokenData = fmt.Sprintf(popAccessTokenWithoutCnf, time.Now().Add(time.Minute*5).Unix())
+	}
+	if b.kid == accessTokenCnfWrong {
+		accessTokenData = fmt.Sprintf(`{ "aud": "client", "iss" : "kd", "exp" : "%d","cnf": {"kid":1} }`, time.Now().Add(time.Minute*5).Unix())
+	}
+
+	at, err := b.swkKey.GenerateToken([]byte(accessTokenData))
+	if err != nil {
+		return fmt.Errorf("Error when generating token. Error:%+v", err)
+	}
+
+	payload := fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, b.ts, b.hostName, b.popKey.Jwk(), nonce)
+	if b.kid == tsClaimsMissing {
+		payload = fmt.Sprintf(`{ "at" : "%s", "u": "%d", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, 1, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == uClaimsMissing {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "cnf":{"jwk":%s}, "nonce":"%s"}`, at, b.ts, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == cnfJwkClaimsEmpty {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{}, "nonce":"%s"}`, at, b.ts, b.hostName, nonce)
+	}
+	if b.kid == cnfJwkClaimsMissing {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":1, "nonce":"%s"}`, at, b.ts, b.hostName, nonce)
+	}
+	if b.kid == cnfJwkClaimsWrong {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{"jwk":1}, "nonce":"%s"}`, at, b.ts, b.hostName, nonce)
+	}
+	if b.kid == cnfClaimsMissing {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "nonce": "%s"}`, at, b.ts, b.hostName, nonce)
+	}
+	if b.kid == tsClaimsTypeString {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : "%s", "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, strconv.FormatInt(b.ts, 10), b.hostName, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == tsClaimsTypeUnknown {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %t, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, bool(true), b.hostName, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == atClaimsWrongType {
+		payload = fmt.Sprintf(`{ "at" : %d, "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, 12, b.ts, b.hostName, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == uClaimsWrongType {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": %d, "cnf":{"jwk":%s}, "nonce":"%s"}`, at, b.ts, 1, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == atClaimsMissing {
+		payload = fmt.Sprintf(`{ "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, b.ts, b.hostName, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == atClaimIncorrect {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, fmt.Sprintf("%s.%s.%s", badTokenKey, badTokenKey, badTokenKey), b.ts, b.hostName, b.popKey.Jwk(), nonce)
+	}
+	b.token.Payload = base64.RawURLEncoding.EncodeToString([]byte(payload))
+	return nil
+}
+
+// A method that sets the signature of the PoP token
+func (b *PoPTokenBuilderImpl) SetSignature() error {
+	if b.kid == signatureWrongType {
+		b.token.Signature = "wrongSignature"
+		return nil
+	}
+	h256 := sha256.Sum256([]byte(b.token.Header + "." + b.token.Payload))
+	signature, err := b.popKey.Sign(h256[:])
+	if err != nil {
+		return fmt.Errorf("Error while signing pop key. Error:%+v", err)
+	}
+	b.token.Signature = base64.RawURLEncoding.EncodeToString(signature)
+	return nil
+}
+
+// A method that returns the final PoP token as a string
+func (b *PoPTokenBuilderImpl) GetToken() (string, error) {
+	var err error
+	b.popKey, err = NewSWPoPKey()
 	if err != nil {
 		return "", fmt.Errorf("Failed to generate Pop key. Error:%+v", err)
 	}
-
-	key, err := NewSwkKey()
+	b.swkKey, err = NewSwkKey()
 	if err != nil {
 		return "", fmt.Errorf("Failed to generate SF key. Error:%+v", err)
 	}
 
-	var cnf string
-	if kid == atCnfClaimWrong {
-		cnf = "wrongCnf"
-	} else {
-		cnf = popKey.KeyID()
+	if strings.Contains(b.kid, badTokenKey) {
+		return b.kid, nil
 	}
 
-	var accessTokenData string
-	if kid == atCnfClaimMissing {
-		accessTokenData = fmt.Sprintf(popAccessTokenWithoutCnf, time.Now().Add(time.Minute*5).Unix())
-	} else {
-		accessTokenData = fmt.Sprintf(popAccessToken, time.Now().Add(time.Minute*5).Unix(), cnf)
-	}
-
-	at, err := key.GenerateToken([]byte(accessTokenData))
+	err = b.SetHeader()
 	if err != nil {
-		return "", fmt.Errorf("Error when generating token. Error:%+v", err)
+		return "", err
 	}
-	var header, headerB64 string
-	nonce := uuid.New().String()
-	nonce = strings.Replace(nonce, "-", "", -1)
-	keyID := popKey.KeyID()
-	algo := popKey.Alg()
-	typ := "pop"
-	if kid == headerBadKeyID {
-		keyID = ""
-	}
-	if kid == headerBadAlgo {
-		algo = "wrong"
-	}
-	if kid == headerBadtyp {
-		typ = "wrong"
-	}
-	header = fmt.Sprintf(`{"typ":"%s","alg":"%s","kid":"%s"}`, typ, algo, keyID)
-
-	if kid == headerBadtypType {
-		wrongTyp := 1
-		header = fmt.Sprintf(`{"typ":%d,"alg":"%s","kid":"%s"}`, wrongTyp, algo, keyID)
-	}
-
-	if kid == headerBadtypMissing {
-		header = fmt.Sprintf(`{"alg":"%s","kid":"%s"}`, algo, keyID)
-	}
-
-	headerB64 = base64.RawURLEncoding.EncodeToString([]byte(header))
-
-	var payload, payloadB64 string
-	payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, ts, hostName, popKey.Jwk(), nonce)
-	if kid == tsClaimsMissing {
-		payload = fmt.Sprintf(`{ "at" : "%s", "u": "%d", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, 1, popKey.Jwk(), nonce)
-	}
-	if kid == uClaimsMissing {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "cnf":{"jwk":%s}, "nonce":"%s"}`, at, ts, popKey.Jwk(), nonce)
-	}
-	if kid == cnfClaimsMissing {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "nonce": "%s"}`, at, ts, hostName, nonce)
-	}
-	if kid == cnfJwkClaimsEmpty {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{}, "nonce":"%s"}`, at, ts, hostName, nonce)
-	}
-	if kid == cnfJwkClaimsWrong {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":1, "nonce":"%s"}`, at, ts, hostName, nonce)
-	}
-	if kid == tsClaimsTypeString {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : "%s", "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, strconv.FormatInt(ts, 10), hostName, popKey.Jwk(), nonce)
-	}
-	if kid == tsClaimsTypeUnknown {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %t, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, bool(true), hostName, popKey.Jwk(), nonce)
-	}
-	if kid == atClaimsWrongType {
-		payload = fmt.Sprintf(`{ "at" : %d, "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, 12, ts, hostName, popKey.Jwk(), nonce)
-	}
-	if kid == uClaimsWrongType {
-		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": %d, "cnf":{"jwk":%s}, "nonce":"%s"}`, at, ts, 1, popKey.Jwk(), nonce)
-	}
-	if kid == atClaimsMissing {
-		payload = fmt.Sprintf(`{ "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, ts, hostName, popKey.Jwk(), nonce)
-	}
-
-	payloadB64 = base64.RawURLEncoding.EncodeToString([]byte(payload))
-	h256 := sha256.Sum256([]byte(headerB64 + "." + payloadB64))
-	signature, err := popKey.Sign(h256[:])
+	err = b.SetPayload()
 	if err != nil {
-		return "", fmt.Errorf("Error while signing pop key. Error:%+v", err)
+		return "", err
 	}
-	signatureB64 := base64.RawURLEncoding.EncodeToString(signature)
+	err = b.SetSignature()
+	if err != nil {
+		return "", err
+	}
 
-	finalToken := headerB64 + "." + payloadB64 + "." + signatureB64
+	finalToken := b.token.Header + "." + b.token.Payload + "." + b.token.Signature
 	return finalToken, nil
 }
 
 func TestPopTokenVerifier_Verify(t *testing.T) {
 	verifier := NewPoPVerifier("testHostname", 15*time.Minute)
 
-	validToken, _ := GeneratePoPToken(time.Now().Unix(), "testHostname", "")
+	validToken, _ := NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").GetToken()
 	_, err := verifier.ValidatePopToken(validToken)
 	assert.NoError(t, err)
 
-	validToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", tsClaimsTypeString)
+	// 'ts' claim is passed as string
+	validToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(tsClaimsTypeString).GetToken()
 	_, err = verifier.ValidatePopToken(validToken)
 	assert.NoError(t, err)
 
-	invalidToken, _ := GeneratePoPToken(time.Now().Unix(), "", badTokenKey)
+	// PoP token is not in the right format
+	invalidToken, _ := NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(badTokenKey).GetToken()
 	_, err = verifier.ValidatePopToken(invalidToken)
 	assert.EqualError(t, err, "PoP token invalid schema. Token length: 1")
 
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", fmt.Sprintf("%s.%s.%s", badTokenKey, badTokenKey, badTokenKey))
+	// PoP token is in the right format but is incorrect and could not be parsed
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(fmt.Sprintf("%s.%s.%s", badTokenKey, badTokenKey, badTokenKey)).GetToken()
 	_, err = verifier.ValidatePopToken(invalidToken)
 	assert.EqualError(t, err, "Could not parse PoP token. Error: invalid character 'm' looking for beginning of value")
 
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", headerBadKeyID)
+	// 'keyID' claim in the header is missing
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(headerBadKeyID).GetToken()
 	_, err = verifier.ValidatePopToken(invalidToken)
 	assert.EqualError(t, err, "No KeyID found in PoP token header")
 
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", headerBadAlgo)
+	// 'algo' claim in the header is incorrect
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(headerBadAlgo).GetToken()
 	_, err = verifier.ValidatePopToken(invalidToken)
 	assert.EqualError(t, err, "Wrong algorithm found in PoP token header, expected 'RS256' having 'wrong'")
 
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", headerBadtyp)
+	// 'typ' claim in the header is incorrect
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(headerBadtyp).GetToken()
 	_, err = verifier.ValidatePopToken(invalidToken)
 	assert.EqualError(t, err, "Wrong typ. Expected 'pop' having 'wrong'")
 
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", headerBadtypMissing)
+	// 'typ' claim is not present in the header
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(headerBadtypMissing).GetToken()
 	_, err = verifier.ValidatePopToken(invalidToken)
 	assert.EqualError(t, err, "Invalid token. 'typ' claim is missing")
 
-	expiredToken, _ := GeneratePoPToken(time.Now().Add(time.Minute*-20).Unix(), "", "")
+	// 'typ' claim in the header is not of string type
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(headerBadtypType).GetToken()
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Invalid token. 'typ' claim should be of string")
+
+	// 'ts' has an expired timestamp
+	expiredToken, _ := NewPoPTokenBuilder().SetTimestamp(time.Now().Add(time.Minute * -20).Unix()).GetToken()
 	_, err = verifier.ValidatePopToken(expiredToken)
 	assert.NotNilf(t, err, "PoP verification succeed.")
 	assert.Containsf(t, err.Error(), "Token is expired", "Error message is not as expected")
 
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", tsClaimsMissing)
+	// 'ts' claim is not present in the payload
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(tsClaimsMissing).GetToken() //(time.Now().Unix(), "", tsClaimsMissing)
 	_, err = verifier.ValidatePopToken(invalidToken)
 	assert.EqualError(t, err, "Invalid token. 'ts' claim is missing")
 
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "wrongHostnme", "")
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid Pop token due to host mismatch. Expected: \"testHostname\", received: \"wrongHostnme\"")
-
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", uClaimsMissing)
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'u' claim is missing")
-
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", cnfClaimsMissing)
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'cnf' claim is missing")
-
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", cnfJwkClaimsEmpty)
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'jwk' claim is empty")
-
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", atCnfClaimMissing)
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "could not retrieve 'cnf' claim from access token")
-
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", atCnfClaimWrong)
-	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "PoP token validate failed: 'cnf' claim mismatch")
-
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", tsClaimsTypeUnknown)
+	// 'ts' claim in the payload is of unknown type and cannot be parsed. 'ts' is set to the default timestamp which has expired
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(tsClaimsTypeUnknown).GetToken()
 	_, err = verifier.ValidatePopToken(invalidToken)
 	assert.Containsf(t, err.Error(), "Token is expired", "Error message is not as expected")
 
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", atClaimsWrongType)
+	// Request and validation for the PoP token are running for different hostnames
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("wrongHostnme").GetToken()
 	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'at' claim should be string")
+	assert.EqualError(t, err, "Invalid Pop token due to host mismatch. Expected: \"testHostname\", received: \"wrongHostnme\"")
 
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", uClaimsWrongType)
+	// 'cnf' is not present in the access token
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(atCnfClaimMissing).GetToken()
 	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'u' claim should be of string")
+	assert.EqualError(t, err, "could not retrieve 'cnf' claim from access token")
 
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", cnfJwkClaimsWrong)
+	// 'cnf' in the access token does not have the right value
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(atCnfClaimWrong).GetToken()
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "PoP token validate failed: 'cnf' claim mismatch")
+
+	// 'cnf' claim in the payload is not present
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(cnfClaimsMissing).GetToken()
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Invalid token. 'cnf' claim is missing")
+
+	// 'cnf' claim in the payload does not have 'jwk'
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(cnfJwkClaimsMissing).GetToken()
 	_, err = verifier.ValidatePopToken(invalidToken)
 	assert.EqualError(t, err, "Invalid token. 'cnf' claim is not in expected format")
 
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", headerBadtypType)
+	// 'jwk' in 'cnf' claim in the payload is empty
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(cnfJwkClaimsEmpty).GetToken()
 	_, err = verifier.ValidatePopToken(invalidToken)
-	assert.EqualError(t, err, "Invalid token. 'typ' claim should be of string")
+	assert.EqualError(t, err, "Invalid token. 'jwk' claim is empty")
 
-	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", atClaimsMissing)
+	// 'jwk' in the 'cnf' claim in the payload is not of string type
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(cnfJwkClaimsWrong).GetToken()
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.ErrorContains(t, err, "failed while parsing 'jwk' claim in PoP token")
+
+	// 'jwk' in the 'cnf' claim in the access token is not of string type
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(accessTokenCnfWrong).GetToken()
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.ErrorContains(t, err, "failed while parsing 'cnf' in access token")
+
+	// 'u' claim is not present in the payload
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetKid(uClaimsMissing).GetToken()
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Invalid token. 'u' claim is missing")
+
+	// 'u' claim in the payload is not of string type
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(uClaimsWrongType).GetToken()
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Invalid token. 'u' claim should be of string")
+
+	// 'at' claim in the payload is not of type string
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(atClaimsWrongType).GetToken()
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Invalid token. 'at' claim should be string")
+
+	// 'at' claim is not present in the payload
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(atClaimsMissing).GetToken()
 	_, err = verifier.ValidatePopToken(invalidToken)
 	assert.EqualError(t, err, "Invalid token. access token missing")
+
+	// 'at' claim value in they payload is not correct and could not be parsed
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(atClaimIncorrect).GetToken()
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.ErrorContains(t, err, "could not parse access token in PoP token")
+
+	// RSA verify error due to invalid signature in the PoP token
+	invalidToken, _ = NewPoPTokenBuilder().SetTimestamp(time.Now().Unix()).SetHostName("testHostname").SetKid(signatureWrongType).GetToken()
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.ErrorContains(t, err, "RSA verify err: crypto/rsa: verification error")
 }

--- a/auth/providers/azure/pop_tokenverifier_test_utils.go
+++ b/auth/providers/azure/pop_tokenverifier_test_utils.go
@@ -1,0 +1,337 @@
+/*
+Copyright The Guard Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gopkg.in/square/go-jose.v2"
+)
+
+const (
+	popAccessToken           = `{ "aud": "client", "iss" : "kd", "exp" : "%d","cnf": {"kid":"%s","xms_ksl":"sw"} }`
+	popAccessTokenWithoutCnf = `{ "aud": "client", "iss" : "kd", "exp" : "%d" }`
+)
+
+type swPoPKey struct {
+	key    *rsa.PrivateKey
+	keyID  string
+	jwk    string
+	jwkTP  string
+	reqCnf string
+}
+
+func (swk *swPoPKey) Alg() string {
+	return "RS256"
+}
+
+func (swk *swPoPKey) Sign(payload []byte) ([]byte, error) {
+	return swk.key.Sign(rand.Reader, payload, crypto.SHA256)
+}
+
+func (swk *swPoPKey) KeyID() string {
+	return swk.keyID
+}
+
+func (swk *swPoPKey) Cnf() string {
+	return swk.reqCnf
+}
+
+func (swk *swPoPKey) Jwk() string {
+	return swk.jwk
+}
+
+func NewSWPoPKey() (*swPoPKey, error) {
+	pop := &swPoPKey{}
+	rsa, err := rsa.GenerateKey(rand.Reader, 1028)
+	if err != nil {
+		return nil, err
+	}
+	pop.key = rsa
+	pubKey := rsa.PublicKey
+	e := big.NewInt(int64(pubKey.E))
+	eB64 := base64.RawURLEncoding.EncodeToString(e.Bytes())
+	n := pubKey.N
+	nB64 := base64.RawURLEncoding.EncodeToString(n.Bytes())
+	jwk := fmt.Sprintf(`{"e":"%s","kty":"RSA","n":"%s"}`, eB64, nB64)
+	jwkS256 := sha256.Sum256([]byte(jwk))
+	pop.jwkTP = base64.RawURLEncoding.EncodeToString(jwkS256[:])
+
+	reqCnfJSON := fmt.Sprintf(`{"kid":"%s","xms_ksl":"sw"}`, pop.jwkTP)
+	pop.reqCnf = base64.RawURLEncoding.EncodeToString([]byte(reqCnfJSON))
+	pop.keyID = pop.jwkTP
+	pop.jwk = fmt.Sprintf(`{"e":"%s","kty":"RSA","n":"%s","alg":"RS256","kid":"%s"}`, eB64, nB64, pop.keyID)
+
+	return pop, nil
+}
+
+type swKey struct {
+	keyID  string
+	pKey   *rsa.PrivateKey
+	pubKey interface{}
+}
+
+func (swk *swKey) Alg() string {
+	return "RS256"
+}
+
+func (swk *swKey) KeyID() string {
+	return ""
+}
+
+func NewSwkKey() (*swKey, error) {
+	rsa, err := rsa.GenerateKey(rand.Reader, 1028)
+	if err != nil {
+		return nil, err
+	}
+	return &swKey{"", rsa, rsa.Public()}, nil
+}
+
+func (swk *swKey) GenerateToken(payload []byte) (string, error) {
+	pKey := &jose.JSONWebKey{Key: swk.pKey, Algorithm: swk.Alg(), KeyID: swk.KeyID()}
+
+	// create a Square.jose RSA signer, used to sign the JWT
+	signerOpts := jose.SignerOptions{}
+	signerOpts.WithType("JWT")
+	rsaSigner, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pKey}, &signerOpts)
+	if err != nil {
+		return "", err
+	}
+	jws, err := rsaSigner.Sign(payload)
+	if err != nil {
+		return "", err
+	}
+
+	token, err := jws.CompactSerialize()
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+const (
+	BadTokenKey         = "badToken"
+	HeaderBadKeyID      = "headerBadKeyID"
+	HeaderBadAlgo       = "headerBadAlgo"
+	HeaderBadtyp        = "headerBadtyp"
+	HeaderBadtypType    = "headerBadtypType"
+	HeaderBadtypMissing = "headerBadtypMissing"
+	UClaimsMissing      = "uClaimsMissing"
+	TsClaimsMissing     = "tsClaimsMissing"
+	AtClaimsMissing     = "atClaimsMissing"
+	AtClaimIncorrect    = "atClaimIncorrect"
+	CnfClaimsMissing    = "cnfClaimsMissing"
+	CnfJwkClaimsEmpty   = "cnfJwkClaimsEmpty"
+	CnfJwkClaimsWrong   = "cnfJwkClaimsWrong"
+	CnfJwkClaimsMissing = "cnfJwkClaimsMissing"
+	AccessTokenCnfWrong = "accessTokenCnfWrong"
+	AtClaimsWrongType   = "atClaimsWrongType"
+	AtCnfClaimMissing   = "atCnfClaimMissing"
+	AtCnfClaimWrong     = "atCnfClaimWrong"
+	TsClaimsTypeString  = "tsClaimsTypeString"
+	TsClaimsTypeUnknown = "tsClaimsTypeUnknown"
+	UClaimsWrongType    = "uClaimsWrongType"
+	SignatureWrongType  = "signatureWrongType"
+)
+
+// A struct that represents a PoP token
+type PoPToken struct {
+	Header    string
+	Payload   string
+	Signature string
+}
+
+// A concrete builder struct that implements the steps to build a PoP token
+type PoPTokenBuilderImpl struct {
+	popKey   *swPoPKey
+	swkKey   *swKey
+	ts       int64
+	hostName string
+	kid      string // used for testing purposes
+	token    PoPToken
+}
+
+// A constructor function that returns a new PoPTokenBuilderImpl
+func NewPoPTokenBuilder() *PoPTokenBuilderImpl {
+	return &PoPTokenBuilderImpl{}
+}
+
+func (b *PoPTokenBuilderImpl) SetTimestamp(ts int64) *PoPTokenBuilderImpl {
+	b.ts = ts
+	return b
+}
+
+func (b *PoPTokenBuilderImpl) SetKid(kid string) *PoPTokenBuilderImpl {
+	b.kid = kid
+	return b
+}
+
+func (b *PoPTokenBuilderImpl) SetHostName(hostName string) *PoPTokenBuilderImpl {
+	b.hostName = hostName
+	return b
+}
+
+// A method that sets the header of the PoP token
+func (b *PoPTokenBuilderImpl) SetHeader() error {
+	keyID := b.popKey.KeyID()
+	algo := b.popKey.Alg()
+	typ := "pop"
+	if b.kid == HeaderBadKeyID {
+		keyID = ""
+	}
+	if b.kid == HeaderBadAlgo {
+		algo = "wrong"
+	}
+	if b.kid == HeaderBadtyp {
+		typ = "wrong"
+	}
+	header := fmt.Sprintf(`{"typ":"%s","alg":"%s","kid":"%s"}`, typ, algo, keyID)
+
+	if b.kid == HeaderBadtypType {
+		wrongTyp := 1
+		header = fmt.Sprintf(`{"typ":%d,"alg":"%s","kid":"%s"}`, wrongTyp, algo, keyID)
+	}
+	if b.kid == HeaderBadtypMissing {
+		header = fmt.Sprintf(`{"alg":"%s","kid":"%s"}`, algo, keyID)
+	}
+	b.token.Header = base64.RawURLEncoding.EncodeToString([]byte(header))
+	return nil
+}
+
+// A method that sets the payload of the PoP token
+func (b *PoPTokenBuilderImpl) SetPayload() error {
+	var cnf string
+	if b.kid == AtCnfClaimWrong {
+		cnf = "wrongCnf"
+	} else {
+		cnf = b.popKey.KeyID()
+	}
+
+	nonce := uuid.New().String()
+	nonce = strings.Replace(nonce, "-", "", -1)
+
+	accessTokenData := fmt.Sprintf(popAccessToken, time.Now().Add(time.Minute*5).Unix(), cnf)
+	if b.kid == AtCnfClaimMissing {
+		accessTokenData = fmt.Sprintf(popAccessTokenWithoutCnf, time.Now().Add(time.Minute*5).Unix())
+	}
+	if b.kid == AccessTokenCnfWrong {
+		accessTokenData = fmt.Sprintf(`{ "aud": "client", "iss" : "kd", "exp" : "%d","cnf": {"kid":1} }`, time.Now().Add(time.Minute*5).Unix())
+	}
+
+	at, err := b.swkKey.GenerateToken([]byte(accessTokenData))
+	if err != nil {
+		return fmt.Errorf("Error when generating token. Error:%+v", err)
+	}
+
+	payload := fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, b.ts, b.hostName, b.popKey.Jwk(), nonce)
+	if b.kid == TsClaimsMissing {
+		payload = fmt.Sprintf(`{ "at" : "%s", "u": "%d", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, 1, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == UClaimsMissing {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "cnf":{"jwk":%s}, "nonce":"%s"}`, at, b.ts, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == CnfJwkClaimsEmpty {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{}, "nonce":"%s"}`, at, b.ts, b.hostName, nonce)
+	}
+	if b.kid == CnfJwkClaimsMissing {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":1, "nonce":"%s"}`, at, b.ts, b.hostName, nonce)
+	}
+	if b.kid == CnfJwkClaimsWrong {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{"jwk":1}, "nonce":"%s"}`, at, b.ts, b.hostName, nonce)
+	}
+	if b.kid == CnfClaimsMissing {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "nonce": "%s"}`, at, b.ts, b.hostName, nonce)
+	}
+	if b.kid == TsClaimsTypeString {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : "%s", "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, strconv.FormatInt(b.ts, 10), b.hostName, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == TsClaimsTypeUnknown {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %t, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, bool(true), b.hostName, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == AtClaimsWrongType {
+		payload = fmt.Sprintf(`{ "at" : %d, "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, 12, b.ts, b.hostName, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == UClaimsWrongType {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": %d, "cnf":{"jwk":%s}, "nonce":"%s"}`, at, b.ts, 1, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == AtClaimsMissing {
+		payload = fmt.Sprintf(`{ "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, b.ts, b.hostName, b.popKey.Jwk(), nonce)
+	}
+	if b.kid == AtClaimIncorrect {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, fmt.Sprintf("%s.%s.%s", BadTokenKey, BadTokenKey, BadTokenKey), b.ts, b.hostName, b.popKey.Jwk(), nonce)
+	}
+	b.token.Payload = base64.RawURLEncoding.EncodeToString([]byte(payload))
+	return nil
+}
+
+// A method that sets the signature of the PoP token
+func (b *PoPTokenBuilderImpl) SetSignature() error {
+	if b.kid == SignatureWrongType {
+		b.token.Signature = "wrongSignature"
+		return nil
+	}
+	h256 := sha256.Sum256([]byte(b.token.Header + "." + b.token.Payload))
+	signature, err := b.popKey.Sign(h256[:])
+	if err != nil {
+		return fmt.Errorf("Error while signing pop key. Error:%+v", err)
+	}
+	b.token.Signature = base64.RawURLEncoding.EncodeToString(signature)
+	return nil
+}
+
+// A method that returns the final PoP token as a string
+func (b *PoPTokenBuilderImpl) GetToken() (string, error) {
+	var err error
+	b.popKey, err = NewSWPoPKey()
+	if err != nil {
+		return "", fmt.Errorf("Failed to generate Pop key. Error:%+v", err)
+	}
+	b.swkKey, err = NewSwkKey()
+	if err != nil {
+		return "", fmt.Errorf("Failed to generate SF key. Error:%+v", err)
+	}
+
+	if strings.Contains(b.kid, BadTokenKey) {
+		return b.kid, nil
+	}
+
+	err = b.SetHeader()
+	if err != nil {
+		return "", err
+	}
+	err = b.SetPayload()
+	if err != nil {
+		return "", err
+	}
+	err = b.SetSignature()
+	if err != nil {
+		return "", err
+	}
+
+	finalToken := b.token.Header + "." + b.token.Payload + "." + b.token.Signature
+	return finalToken, nil
+}


### PR DESCRIPTION
* The goal of this PR is to improve the test coverage. All of the happy path and error cases (where feasible) are covered by unit tests.
* In order to improve the readability of the tests, the test code that makes the test PoP tokens has been refactored. The existing code was hard to extend for new scenarios and hard to follow. The new code uses a builder pattern to create the tokens.

Previous test coverage was ~80%
Current test coverage is 91.5%

 
<img width="463" alt="image" src="https://github.com/kubeguard/guard/assets/25529913/3eb7cbb4-7e6e-426d-8d16-9cad82b84146">

