### PR TITLE
log token claims at verbose level when failing token verification

### DIFF
--- a/auth/providers/azure/token_test.go
+++ b/auth/providers/azure/token_test.go
@@ -1,0 +1,37 @@
+package azure
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+func TestExtractTokenClaimsWithValidToken(t *testing.T) {
+	mySigningKey := []byte("AllYourBase")
+
+	// Create the Claims
+	claims := &jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(time.Unix(1516239022, 0)),
+		Issuer:    "test",
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	ss, err := token.SignedString(mySigningKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	extractedClaims, err := extractTokenClaims(ss)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("claims: %s", extractedClaims)
+}
+
+func TestExtractTokenClaimsWithInvalidToken(t *testing.T) {
+	_, err := extractTokenClaims("")
+	if err == nil {
+		t.Fatal("expected to see the error with invalid token")
+	}
+}

--- a/auth/providers/azure/token_test.go
+++ b/auth/providers/azure/token_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Guard Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package azure
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-ldap/ldap/v3 v3.4.4
 	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/google/go-github/v50 v50.1.0
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.3.0
@@ -81,7 +82,6 @@ require (
 	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect


### PR DESCRIPTION
log token claims at verbose level when failing token verification. 
this may enable debugging on the source of the token