### PR TITLE
[authz/azure] fix: drop global shared username variable

### DIFF
--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -408,8 +408,8 @@ func newUserInfo(tokenProvider TokenProvider, graphURL *url.URL, useGroupUID boo
 
 // New returns a new UserInfo object
 func New(clientID, clientSecret, tenantID string, useGroupUID bool, aadEndpoint, msgraphHost string) (*UserInfo, error) {
-	graphEndpoint := "https://" + msgraphHost + "/"
-	graphURL, _ := url.Parse(graphEndpoint + "v1.0")
+	graphEndpoint := "https://" + msgraphHost + "/"  //nolint:goconst // expected url building
+	graphURL, _ := url.Parse(graphEndpoint + "v1.0") //nolint:goconst // expected url building
 
 	tokenProvider := NewClientCredentialTokenProvider(clientID, clientSecret,
 		fmt.Sprintf("%s%s/oauth2/v2.0/token", aadEndpoint, tenantID),
@@ -420,8 +420,8 @@ func New(clientID, clientSecret, tenantID string, useGroupUID bool, aadEndpoint,
 
 // NewWithOBO returns a new UserInfo object
 func NewWithOBO(clientID, clientSecret, tenantID string, aadEndpoint, msgraphHost string) (*UserInfo, error) {
-	graphEndpoint := "https://" + msgraphHost + "/"
-	graphURL, _ := url.Parse(graphEndpoint + "v1.0")
+	graphEndpoint := "https://" + msgraphHost + "/"  //nolint:goconst // expected url building
+	graphURL, _ := url.Parse(graphEndpoint + "v1.0") //nolint:goconst // expected url building
 
 	tokenProvider := NewOBOTokenProvider(clientID, clientSecret,
 		fmt.Sprintf("%s%s/oauth2/v2.0/token", aadEndpoint, tenantID),
@@ -432,8 +432,8 @@ func NewWithOBO(clientID, clientSecret, tenantID string, aadEndpoint, msgraphHos
 
 // NewWithAKS returns a new UserInfo object used in AKS
 func NewWithAKS(tokenURL, tenantID, msgraphHost string) (*UserInfo, error) {
-	graphEndpoint := "https://" + msgraphHost + "/"
-	graphURL, _ := url.Parse(graphEndpoint + "v1.0")
+	graphEndpoint := "https://" + msgraphHost + "/"  //nolint:goconst // expected url building
+	graphURL, _ := url.Parse(graphEndpoint + "v1.0") //nolint:goconst // expected url building
 
 	tokenProvider := NewAKSTokenProvider(tokenURL, tenantID)
 

--- a/authz/providers/azure/rbac/checkaccessreqhelper.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper.go
@@ -47,10 +47,7 @@ const (
 	PodsResource                = "pods"
 )
 
-var (
-	username               string
-	getStoredOperationsMap = azureutils.DeepCopyOperationsMap
-)
+var getStoredOperationsMap = azureutils.DeepCopyOperationsMap
 
 type SubjectInfoAttributes struct {
 	ObjectId string   `json:"ObjectId"`
@@ -506,7 +503,6 @@ func prepareCheckAccessRequestBody(req *authzv1.SubjectAccessReviewSpec, cluster
 		return nil, errutils.WithCode(errors.New("oid info not sent from authentication module"), http.StatusBadRequest)
 	}
 	groups := getValidSecurityGroups(req.Groups)
-	username = req.User
 	actions, err := getDataActions(req, clusterType)
 	if err != nil {
 		return nil, errutils.WithCode(errors.Wrap(err, "Error while creating list of dataactions for check access call"), http.StatusInternalServerError)
@@ -542,7 +538,7 @@ func getNameSpaceScope(req *authzv1.SubjectAccessReviewSpec, useNamespaceResourc
 	return false, namespace
 }
 
-func ConvertCheckAccessResponse(body []byte) (*authzv1.SubjectAccessReviewStatus, error) {
+func ConvertCheckAccessResponse(username string, body []byte) (*authzv1.SubjectAccessReviewStatus, error) {
 	var (
 		response []AuthorizationDecision
 		allowed  bool

--- a/authz/providers/azure/rbac/rbac_test.go
+++ b/authz/providers/azure/rbac/rbac_test.go
@@ -123,7 +123,7 @@ func TestCheckAccess(t *testing.T) {
 		"actionId":"Microsoft.Kubernetes/connectedClusters/pods/delete",
 		"isDataAction":true,"roleAssignment":null,"denyAssignment":null,"timeToLiveInMs":300000}]`
 
-		ts, u := getAPIServerAndAccessInfo(http.StatusOK, validBody, "arc", "resourceid")
+		ts, u := getAPIServerAndAccessInfo(http.StatusOK, validBody, "aks", "aks-managed-cluster")
 		defer ts.Close()
 
 		requestTimes := 5


### PR DESCRIPTION
Fix #384 

The username is stored in package level, which is not safe for concurrent access. This pull request fixed by removing this variable and propagate the username in the request helper methods.

A unit test has been added in this patch, before the fix, we can reproduce this issue with this:

```
$ cd authz/providers/azure
$ go test -v -race ./...
=== RUN   TestCheckAccess/concurrent_access_to_CheckAccess_method
==================
WARNING: DATA RACE
Write at 0x000104760020 by goroutine 123:
  go.kubeguard.dev/guard/authz/providers/azure/rbac.prepareCheckAccessRequestBody()
      <path>/guard/authz/providers/azure/rbac/checkaccessreqhelper.go:509 +0x27c
  go.kubeguard.dev/guard/authz/providers/azure/rbac.(*AccessInfo).CheckAccess()
      <path>/guard/authz/providers/azure/rbac/rbac.go:296 +0xa8
  go.kubeguard.dev/guard/authz/providers/azure/rbac.TestCheckAccess.func4.1()
      <path>/guard/authz/providers/azure/rbac/rbac_test.go:149 +0x78
  go.kubeguard.dev/guard/authz/providers/azure/rbac.TestCheckAccess.func4.3()
      <path>/guard/authz/providers/azure/rbac/rbac_test.go:154 +0x44

Previous write at 0x000104760020 by goroutine 120:
  go.kubeguard.dev/guard/authz/providers/azure/rbac.prepareCheckAccessRequestBody()
      <path>/guard/authz/providers/azure/rbac/checkaccessreqhelper.go:509 +0x27c
  go.kubeguard.dev/guard/authz/providers/azure/rbac.(*AccessInfo).CheckAccess()
      <path>/guard/authz/providers/azure/rbac/rbac.go:296 +0xa8
  go.kubeguard.dev/guard/authz/providers/azure/rbac.TestCheckAccess.func4.1()
      <path>/guard/authz/providers/azure/rbac/rbac_test.go:149 +0x78
  go.kubeguard.dev/guard/authz/providers/azure/rbac.TestCheckAccess.func4.3()
      <path>/guard/authz/providers/azure/rbac/rbac_test.go:154 +0x44

Goroutine 123 (running) created at:
  go.kubeguard.dev/guard/authz/providers/azure/rbac.TestCheckAccess.func4()
      <path>/guard/authz/providers/azure/rbac/rbac_test.go:147 +0x500
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1648 +0x40

Goroutine 120 (running) created at:
  go.kubeguard.dev/guard/authz/providers/azure/rbac.TestCheckAccess.func4()
      <path>/guard/authz/providers/azure/rbac/rbac_test.go:147 +0x500
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1648 +0x40
==================
```

Above test error indicates the variable was being write/read in different goroutines (HTTP handler) without protection.

After the fix, the test can pass with `-race` enabled.