### PR TITLE
Fix idtyp issue with GetMemberGroupsUsingARCOboService

### DIFF
--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -202,8 +202,17 @@ func (u *UserInfo) getMemberGroupsUsingARCOboService(ctx context.Context, access
 		return nil, errors.Wrap(err, "Error while parsing accessToken for validation")
 	}
 
-	// the arc obo service does not support getting groups for applications
-	if claims[idtypClaim] != nil && !strings.EqualFold(claims[idtypClaim].(string), "user") {
+	// the arc obo service does not support getting groups for applications(SPN)
+	isAADUser := false
+	if (claims[idtypClaim] == nil) {
+		isAADUser = true
+	} else {
+		idtyp, ok := claims[idtypClaim].(string)
+		if ok && strings.EqualFold(idtyp, "user") {
+			isAADUser = true
+		}
+	}
+	if !isAADUser {
 		return nil, errors.New("Overage claim (users with more than 200 group membership) for SPN is currently not supported. For troubleshooting, please refer to aka.ms/overageclaimtroubleshoot")
 	}
 

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -204,7 +204,7 @@ func (u *UserInfo) getMemberGroupsUsingARCOboService(ctx context.Context, access
 
 	// the arc obo service does not support getting groups for applications(SPN)
 	isAADUser := false
-	if (claims[idtypClaim] == nil) {
+	if claims[idtypClaim] == nil {
 		isAADUser = true
 	} else {
 		idtyp, ok := claims[idtypClaim].(string)

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -76,7 +76,7 @@ const (
 	getMemberGroupsTimeout = 23 * time.Second
 	getterName             = "ms-graph"
 	arcAuthMode            = "arc"
-	arcOboEndpointFormat   = "https://eastus2euap.aks-test.obo.arc.azure.%s:8084%s/getMemberGroups?api-version=v1"
+	arcOboEndpointFormat   = "https://%s.obo.arc.azure.%s:8084%s/getMemberGroups?api-version=v1"
 )
 
 // UserInfo allows you to get user data from MS Graph
@@ -307,7 +307,7 @@ func getOBORegionalEndpointFunc(location string, resourceID string) (string, err
 	if !strings.HasPrefix(resourceID, "/") {
 		resourceID = "/" + resourceID
 	}
-	return fmt.Sprintf(arcOboEndpointFormat, suffix, resourceID), nil
+	return fmt.Sprintf(arcOboEndpointFormat, location, suffix, resourceID), nil
 }
 
 func (u *UserInfo) RefreshToken(ctx context.Context, token string) error {

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -76,7 +76,7 @@ const (
 	getMemberGroupsTimeout = 23 * time.Second
 	getterName             = "ms-graph"
 	arcAuthMode            = "arc"
-	arcOboEndpointFormat   = "https://%s.obo.arc.azure.%s:8084%s/getMemberGroups?api-version=v1"
+	arcOboEndpointFormat   = "https://eastus2euap.aks-test.obo.arc.azure.%s:8084%s/getMemberGroups?api-version=v1"
 )
 
 // UserInfo allows you to get user data from MS Graph
@@ -203,7 +203,7 @@ func (u *UserInfo) getMemberGroupsUsingARCOboService(ctx context.Context, access
 	}
 
 	// the arc obo service does not support getting groups for applications
-	if claims[idtypClaim] != nil {
+	if claims[idtypClaim] != nil && !strings.EqualFold(claims[idtypClaim].(string), "user") {
 		return nil, errors.New("Overage claim (users with more than 200 group membership) for SPN is currently not supported. For troubleshooting, please refer to aka.ms/overageclaimtroubleshoot")
 	}
 
@@ -307,7 +307,7 @@ func getOBORegionalEndpointFunc(location string, resourceID string) (string, err
 	if !strings.HasPrefix(resourceID, "/") {
 		resourceID = "/" + resourceID
 	}
-	return fmt.Sprintf(arcOboEndpointFormat, location, suffix, resourceID), nil
+	return fmt.Sprintf(arcOboEndpointFormat, suffix, resourceID), nil
 }
 
 func (u *UserInfo) RefreshToken(ctx context.Context, token string) error {

--- a/auth/providers/azure/graph/graph_test.go
+++ b/auth/providers/azure/graph/graph_test.go
@@ -36,6 +36,7 @@ import (
 const (
 	accessTokenWithOverageClaim       = `{ "aud": "client", "iss" : "%v", "exp" : "%v",  "upn": "arc", "_claim_names": {"groups": "src1"}, "_claim_sources": {"src1": {"endpoint": "https://foobar" }} }`
 	accessTokenWithOverageClaimForApp = `{ "aud": "client", "iss" : "%v", "exp" : "%v", "idtyp" : "app", "upn": "arc", "_claim_names": {"groups": "src1"}, "_claim_sources": {"src1": {"endpoint": "https://foobar" }} }`
+	accessTokenWithOverageClaimForUser = `{ "aud": "client", "iss" : "%v", "exp" : "%v", "idtyp" : "user", "upn": "arc", "_claim_names": {"groups": "src1"}, "_claim_sources": {"src1": {"endpoint": "https://foobar" }} }`
 	location                          = "eastus"
 	tenant_id                         = "tenantId"
 )
@@ -334,6 +335,39 @@ func TestGetMemberGroupsUsingARCOboService(t *testing.T) {
 		u.headers.Set("Authorization", "Bearer msitoken")
 
 		tokenstring, err := key.GenerateToken([]byte(fmt.Sprintf(accessTokenWithOverageClaim, ts.URL, time.Now().Add(time.Minute*5).Unix())))
+		if err != nil {
+			t.Fatalf("Error when generating token. Error:%+v", err)
+		}
+
+		groups, err := u.getMemberGroupsUsingARCOboService(ctx, tokenstring)
+		if err != nil {
+			t.Errorf("Should not have gotten error: %s", err)
+		}
+		if len(groups) != 1 {
+			t.Errorf("Should have gotten a list of groups with 1 entry. Got: %d", len(groups))
+		}
+	})
+	t.Run("successful request for token with 'user' idtyp claim", func(t *testing.T) {
+		validBody := `{
+			"value": [
+				"f36ec2c5-fa5t-4f05-b87f-deadbeef"
+			]
+		  }`
+
+		ts, u := getAPIServerAndUserInfo(http.StatusOK, validBody)
+		u.region = location
+		u.authMode = arcAuthMode
+		u.resourceID = ts.URL
+		u.tenantID = tenant_id
+		defer ts.Close()
+
+		getOBORegionalEndpoint = func(location string, resourceID string) (string, error) {
+			return ts.URL, nil
+		}
+
+		u.headers.Set("Authorization", "Bearer msitoken")
+
+		tokenstring, err := key.GenerateToken([]byte(fmt.Sprintf(accessTokenWithOverageClaimForUser, ts.URL, time.Now().Add(time.Minute*5).Unix())))
 		if err != nil {
 			t.Fatalf("Error when generating token. Error:%+v", err)
 		}

--- a/auth/providers/azure/graph/graph_test.go
+++ b/auth/providers/azure/graph/graph_test.go
@@ -34,11 +34,11 @@ import (
 )
 
 const (
-	accessTokenWithOverageClaim       = `{ "aud": "client", "iss" : "%v", "exp" : "%v",  "upn": "arc", "_claim_names": {"groups": "src1"}, "_claim_sources": {"src1": {"endpoint": "https://foobar" }} }`
-	accessTokenWithOverageClaimForApp = `{ "aud": "client", "iss" : "%v", "exp" : "%v", "idtyp" : "app", "upn": "arc", "_claim_names": {"groups": "src1"}, "_claim_sources": {"src1": {"endpoint": "https://foobar" }} }`
+	accessTokenWithOverageClaim        = `{ "aud": "client", "iss" : "%v", "exp" : "%v",  "upn": "arc", "_claim_names": {"groups": "src1"}, "_claim_sources": {"src1": {"endpoint": "https://foobar" }} }`
+	accessTokenWithOverageClaimForApp  = `{ "aud": "client", "iss" : "%v", "exp" : "%v", "idtyp" : "app", "upn": "arc", "_claim_names": {"groups": "src1"}, "_claim_sources": {"src1": {"endpoint": "https://foobar" }} }`
 	accessTokenWithOverageClaimForUser = `{ "aud": "client", "iss" : "%v", "exp" : "%v", "idtyp" : "user", "upn": "arc", "_claim_names": {"groups": "src1"}, "_claim_sources": {"src1": {"endpoint": "https://foobar" }} }`
-	location                          = "eastus"
-	tenant_id                         = "tenantId"
+	location                           = "eastus"
+	tenant_id                          = "tenantId"
 )
 
 type swKey struct {


### PR DESCRIPTION
- During testing authentication flow in Guard for a user token (with overage claims), noticed that it is treated as SPN/Application and failed the authentication

- Looks like Microsoft identity platform has changed the format for user tokens and is now setting optional "idtyp" claim. This needs a change in Guard on how we evaluate if the token corresponds to an AAD User or an Application (SPN)

For more context,
"idtyp" claim is used to get the type of token (app, user, device). By default, it's only emitted for app-only tokens (which seems to have changed now)
Like all optional claims that affect the access token, the resource in the request must set this optional claim, since resources own the access token
https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference#additionalproperties-of-optional-claims
