### PR TITLE
Adding HTTP2 transport settings in util/httpclient

### DIFF
--- a/util/httpclient/utils.go
+++ b/util/httpclient/utils.go
@@ -25,9 +25,37 @@ import (
 	"time"
 
 	"golang.org/x/net/http2"
+	"k8s.io/klog/v2"
 )
 
-var DefaultHTTPClient *http.Client
+var (
+	DefaultHTTPClient             *http.Client
+	http2ClientPingEnabled        bool
+	http2TransportReadIdleTimeout time.Duration
+	http2TransportPingTimeout     time.Duration
+)
+
+const (
+	readIdleTimeout = 30 * time.Second
+	pingTimeout     = 5 * time.Second
+)
+
+// initOsEnv initializes the environment variables
+// We are enabling 3 env variables to control the HTTP2 client ping feature:
+// 1. HTTP2_CLIENT_PING_ENABLED: If set to true, the transport will setup http2 ping
+// 2. HTTP2_TRANSPORT_READ_IDLE_TIMEOUT: The duration after which the connection will be closed if it has been idle
+// 3. HTTP2_TRANSPORT_PING_TIMEOUT: The duration after which the connection will be closed if there's no response to the ping
+func initOsEnv() {
+	http2ClientPingEnabled, _ = strconv.ParseBool(os.Getenv("HTTP2_TRANSPORT_PING_ENABLED"))
+	http2TransportReadIdleTimeout = readIdleTimeout
+	if val, err := time.ParseDuration(os.Getenv("HTTP2_TRANSPORT_READ_IDLE_TIMEOUT")); err == nil && val > 0 {
+		http2TransportReadIdleTimeout = val
+	}
+	http2TransportPingTimeout = pingTimeout
+	if val, err := time.ParseDuration(os.Getenv("HTTP2_TRANSPORT_PING_TIMEOUT")); err == nil && val > 0 {
+		http2TransportPingTimeout = val
+	}
+}
 
 func init() {
 	defaultTransport := &http.Transport{
@@ -46,15 +74,17 @@ func init() {
 			MinVersion: tls.VersionTLS12,
 		},
 	}
+	initOsEnv()
 	// If HTTP2_CLIENT_PING_ENABLED env var is set, the transport will setup http2 ping
-	v, _ := strconv.ParseBool(os.Getenv("HTTP2_CLIENT_PING_ENABLED"))
-	if v {
+	http2ClientPingEnabled, _ := strconv.ParseBool(os.Getenv("HTTP2_CLIENT_PING_ENABLED"))
+	if http2ClientPingEnabled {
 		tr2 := defaultTransport.Clone()
 		if http2Transport, err := http2.ConfigureTransports(tr2); err == nil {
-			// if the connection has been idle for 3 seconds, send a ping frame for a health check
-			http2Transport.ReadIdleTimeout = 3 * time.Second
+			klog.V(10).Infof("HTTP2 client ping enabled with read idle timeout: %v and ping timeout: %v", http2TransportReadIdleTimeout, http2TransportPingTimeout)
+			// if the connection has been idle for 30 seconds, send a ping frame for a health check
+			http2Transport.ReadIdleTimeout = http2TransportReadIdleTimeout
 			// if there's no response to the ping within the timeout, the connection will be closed
-			http2Transport.PingTimeout = 2 * time.Second
+			http2Transport.PingTimeout = http2TransportPingTimeout
 			DefaultHTTPClient = &http.Client{
 				Transport: tr2,
 			}
@@ -64,4 +94,17 @@ func init() {
 	DefaultHTTPClient = &http.Client{
 		Transport: defaultTransport,
 	}
+}
+
+// Getter functions to access the read-only variables
+func IsHTTP2ClientPingEnabled() bool {
+	return http2ClientPingEnabled
+}
+
+func GetHTTP2TransportReadIdleTimeout() time.Duration {
+	return http2TransportReadIdleTimeout
+}
+
+func GetHTTP2TransportPingTimeout() time.Duration {
+	return http2TransportPingTimeout
 }

--- a/util/httpclient/utils_test.go
+++ b/util/httpclient/utils_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Guard Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package httpclient
 
 import (

--- a/util/httpclient/utils_test.go
+++ b/util/httpclient/utils_test.go
@@ -1,0 +1,86 @@
+package httpclient
+
+import (
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPClientInitialization(t *testing.T) {
+	tests := []struct {
+		name                           string
+		envVars                        map[string]string
+		expectedHTTP2ClientPingEnabled bool
+		expectedReadIdleTimeout        time.Duration
+		expectedPingTimeout            time.Duration
+	}{
+		{
+			name: "HTTP2 client ping enabled with custom timeouts",
+			envVars: map[string]string{
+				"HTTP2_TRANSPORT_PING_ENABLED":      "true",
+				"HTTP2_TRANSPORT_READ_IDLE_TIMEOUT": "45s",
+				"HTTP2_TRANSPORT_PING_TIMEOUT":      "10s",
+			},
+			expectedHTTP2ClientPingEnabled: true,
+			expectedReadIdleTimeout:        45 * time.Second,
+			expectedPingTimeout:            10 * time.Second,
+		},
+		{
+			name: "HTTP2 client ping disabled",
+			envVars: map[string]string{
+				"HTTP2_TRANSPORT_PING_ENABLED": "false",
+			},
+			expectedHTTP2ClientPingEnabled: false,
+			expectedReadIdleTimeout:        30 * time.Second,
+			expectedPingTimeout:            5 * time.Second,
+		},
+		{
+			name: "HTTP2 client ping enabled with default timeouts",
+			envVars: map[string]string{
+				"HTTP2_TRANSPORT_PING_ENABLED": "true",
+			},
+			expectedHTTP2ClientPingEnabled: true,
+			expectedReadIdleTimeout:        30 * time.Second,
+			expectedPingTimeout:            5 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+			}
+
+			// Reinitialize the HTTP client
+			initOsEnv()
+
+			// Check if the HTTP2 client ping is enabled
+			assert.Equal(t, tt.expectedHTTP2ClientPingEnabled, IsHTTP2ClientPingEnabled())
+
+			// Check the read idle timeout
+			assert.Equal(t, tt.expectedReadIdleTimeout, GetHTTP2TransportReadIdleTimeout())
+
+			// Check the ping timeout
+			assert.Equal(t, tt.expectedPingTimeout, GetHTTP2TransportPingTimeout())
+
+			// Unset environment variables
+			for key := range tt.envVars {
+				os.Unsetenv(key)
+			}
+		})
+	}
+}
+
+func TestDefaultHTTPClient(t *testing.T) {
+	assert.NotNil(t, DefaultHTTPClient)
+	assert.IsType(t, &http.Client{}, DefaultHTTPClient)
+	assert.Equal(t, 100, DefaultHTTPClient.Transport.(*http.Transport).MaxIdleConns)
+	assert.Equal(t, 100, DefaultHTTPClient.Transport.(*http.Transport).MaxIdleConnsPerHost)
+	assert.Equal(t, 90*time.Second, DefaultHTTPClient.Transport.(*http.Transport).IdleConnTimeout)
+	assert.Equal(t, 10*time.Second, DefaultHTTPClient.Transport.(*http.Transport).TLSHandshakeTimeout)
+	assert.Equal(t, 1*time.Second, DefaultHTTPClient.Transport.(*http.Transport).ExpectContinueTimeout)
+}

--- a/util/httpclient/utils_test.go
+++ b/util/httpclient/utils_test.go
@@ -46,6 +46,17 @@ func TestHTTPClientInitialization(t *testing.T) {
 			expectedReadIdleTimeout:        30 * time.Second,
 			expectedPingTimeout:            5 * time.Second,
 		},
+		{
+			name: "HTTP2 client ping enabled with defaults values when using invalid timeouts",
+			envVars: map[string]string{
+				"HTTP2_TRANSPORT_PING_ENABLED":      "true",
+				"HTTP2_TRANSPORT_READ_IDLE_TIMEOUT": "whatever",
+				"HTTP2_TRANSPORT_PING_TIMEOUT":      "whatever",
+			},
+			expectedHTTP2ClientPingEnabled: true,
+			expectedReadIdleTimeout:        30 * time.Second,
+			expectedPingTimeout:            5 * time.Second,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Related to #395

This pull request introduces a new feature to enable HTTP2 client ping with configurable timeouts via environment variables. The changes include updates to the HTTP client initialization and the addition of new tests to ensure the feature works as expected.

Using the 3 following env variables : 
```
HTTP2_TRANSPORT_PING_ENABLED           // bool
HTTP2_TRANSPORT_READ_IDLE_TIMEOUT      // time.Duration
HTTP2_TRANSPORT_PING_TIMEOUT           // time.Duration
```

### HTTP Client Enhancements:

* Added support for HTTP2 client ping with configurable read idle timeout and ping timeout via environment variables in `util/httpclient/utils.go`.
* Modified the HTTP client initialization to set up HTTP2 ping if the corresponding environment variable is enabled.

### Testing:

* Added comprehensive tests in `util/httpclient/utils_test.go` to verify the HTTP2 client ping functionality and default HTTP client properties.