### PR TITLE
[BUG/FIX] Azure RBAC fix refresh token logic

### DIFF
--- a/auth/providers/azure/azure_test.go
+++ b/auth/providers/azure/azure_test.go
@@ -46,7 +46,7 @@ var jsonLib = jsoniter.ConfigCompatibleWithStandardLibrary
 const (
 	username                       = "nahid"
 	objectID                       = "abc-123d4"
-	loginResp                      = `{ "token_type": "Bearer", "expires_in": 8459, "access_token": "%v"}`
+	loginResp                      = `{ "token_type": "Bearer", "expires_on": 1732881796, "access_token": "%v"}`
 	accessToken                    = `{ "aud": "client_id", "iss" : "%v", "upn": "nahid", "groups": [ "1", "2", "3"] }`
 	accessTokenWithOid             = `{ "aud": "client_id","iss" : "%v", "oid": "abc-123d4", "groups": [ "1", "2", "3"] }`
 	accessTokenWithUpnAndOid       = `{ "aud": "client_id","iss" : "%v", "upn": "nahid", "oid": "abc-123d4", "groups": [ "1", "2", "3"] }`

--- a/auth/providers/azure/graph/aks_tokenprovider_test.go
+++ b/auth/providers/azure/graph/aks_tokenprovider_test.go
@@ -28,7 +28,7 @@ func TestAKSTokenProvider(t *testing.T) {
 		inputAccessToken    = "inputAccessToken"
 		oboAccessToken      = "oboAccessToken"
 		tenantID            = "tenantID"
-		oboResponse         = `{"token_type":"Bearer","expires_in":3599,"access_token":"%s"}`
+		oboResponse         = `{"token_type":"Bearer","expires_on":1732881796,"access_token":"%s"}`
 		expectedContentType = "application/json"
 		expectedTokneType   = "Bearer"
 	)

--- a/auth/providers/azure/graph/clientcredential_tokenprovider_test.go
+++ b/auth/providers/azure/graph/clientcredential_tokenprovider_test.go
@@ -30,7 +30,7 @@ func TestClientCredentialTokenProvider(t *testing.T) {
 		clientID            = "fakeID"
 		clientSecret        = "fakeSecret"
 		scope               = "https://graph.microsoft.com/.default"
-		oboResponse         = `{"token_type":"Bearer","expires_in":3599,"access_token":"%s"}`
+		oboResponse         = `{"token_type":"Bearer","expires_on":1732881796,"access_token":"%s"}`
 		expectedContentType = "application/x-www-form-urlencoded"
 		expectedGrantType   = "client_credentials"
 		expectedTokneType   = "Bearer"

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -72,6 +72,7 @@ var (
 )
 
 const (
+	// Time delta to refresh token before expiry
 	tokenExpiryDelta       = 300 * time.Second
 	getMemberGroupsTimeout = 23 * time.Second
 	getterName             = "ms-graph"

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -72,7 +72,7 @@ var (
 )
 
 const (
-	expiryDelta            = 60 * time.Second
+	expiryDelta            = 300 * time.Second
 	getMemberGroupsTimeout = 23 * time.Second
 	getterName             = "ms-graph"
 	arcAuthMode            = "arc"
@@ -327,11 +327,13 @@ func (u *UserInfo) RefreshToken(ctx context.Context, token string) error {
 		if err != nil {
 			return errors.Errorf("%s: failed to refresh token: %s", u.tokenProvider.Name(), err)
 		}
+		klog.Infof("Token received with expires_in %d and expires_at %d", resp.Expires, resp.ExpiresOn)
 		// Set the authorization headers for future requests
 		u.headers.Set("Authorization", fmt.Sprintf("Bearer %s", resp.Token))
-		expIn := time.Duration(resp.Expires) * time.Second
-		u.expires = time.Now().Add(expIn - expiryDelta)
-		klog.Infof("Token refreshed successfully on %s. Expire at:%s", time.Now(), u.expires)
+		// Use ExpiresOn to set the expiration time
+		expOn := time.Unix(int64(resp.ExpiresOn), 0)
+		u.expires = expOn.Add(-expiryDelta)
+		klog.Infof("Token refreshed successfully on %s. Expire at: %s", time.Now(), u.expires)
 	}
 
 	return nil

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -72,7 +72,7 @@ var (
 )
 
 const (
-	expiryDelta            = 300 * time.Second
+	tokenExpiryDelta       = 300 * time.Second
 	getMemberGroupsTimeout = 23 * time.Second
 	getterName             = "ms-graph"
 	arcAuthMode            = "arc"
@@ -332,7 +332,7 @@ func (u *UserInfo) RefreshToken(ctx context.Context, token string) error {
 		u.headers.Set("Authorization", fmt.Sprintf("Bearer %s", resp.Token))
 		// Use ExpiresOn to set the expiration time
 		expOn := time.Unix(int64(resp.ExpiresOn), 0)
-		u.expires = expOn.Add(-expiryDelta)
+		u.expires = expOn.Add(-tokenExpiryDelta)
 		klog.Infof("Token refreshed successfully at %s. Expire at set to: %s", time.Now(), u.expires)
 	}
 

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -327,7 +327,7 @@ func (u *UserInfo) RefreshToken(ctx context.Context, token string) error {
 		if err != nil {
 			return errors.Errorf("%s: failed to refresh token: %s", u.tokenProvider.Name(), err)
 		}
-		klog.Infof("Token received with expires_in %d and expires_at %d", resp.Expires, resp.ExpiresOn)
+		klog.Infof("Token received with expires_in %d and expires_at %d", resp.ExpiresIn, resp.ExpiresOn)
 		// Set the authorization headers for future requests
 		u.headers.Set("Authorization", fmt.Sprintf("Bearer %s", resp.Token))
 		// Use ExpiresOn to set the expiration time

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -328,7 +328,7 @@ func (u *UserInfo) RefreshToken(ctx context.Context, token string) error {
 		if err != nil {
 			return errors.Errorf("%s: failed to refresh token: %s", u.tokenProvider.Name(), err)
 		}
-		klog.Infof("Token received with expires_in %d and expires_at %d", resp.ExpiresIn, resp.ExpiresOn)
+		klog.Infof("Token received, expires_at %d", resp.ExpiresOn)
 		// Set the authorization headers for future requests
 		u.headers.Set("Authorization", fmt.Sprintf("Bearer %s", resp.Token))
 		// Use ExpiresOn to set the expiration time

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -333,7 +333,7 @@ func (u *UserInfo) RefreshToken(ctx context.Context, token string) error {
 		// Use ExpiresOn to set the expiration time
 		expOn := time.Unix(int64(resp.ExpiresOn), 0)
 		u.expires = expOn.Add(-expiryDelta)
-		klog.Infof("Token refreshed successfully on %s. Expire at: %s", time.Now(), u.expires)
+		klog.Infof("Token refreshed successfully at %s. Expire at set to: %s", time.Now(), u.expires)
 	}
 
 	return nil

--- a/auth/providers/azure/graph/graph_test.go
+++ b/auth/providers/azure/graph/graph_test.go
@@ -110,8 +110,8 @@ func TestLogin(t *testing.T) {
   "access_token": "%s",
   "expires_on": %d
 }`
-		expiresOn := time.Now().Add(time.Second * 3599).Unix()
-		ts, u := getAuthServerAndUserInfo(http.StatusOK, fmt.Sprintf(validBody, validToken, expiresOn), "jason", "bourne")
+		expiresOn := time.Now().Add(time.Second * 3599)
+		ts, u := getAuthServerAndUserInfo(http.StatusOK, fmt.Sprintf(validBody, validToken, expiresOn.Unix()), "jason", "bourne")
 		defer ts.Close()
 		err := u.RefreshToken(ctx, "")
 		if err != nil {
@@ -122,6 +122,10 @@ func TestLogin(t *testing.T) {
 		}
 		if !time.Now().Before(u.expires) {
 			t.Errorf("Expiry not set properly. Expected it to be after the current time. Actual: %v", u.expires)
+		}
+		// Expect u.expires to be tokenExpiryDelta before expiresOn
+		if expiresOn.Add(-tokenExpiryDelta).Equal(u.expires) {
+			t.Errorf("Expiry not set properly. Expected it to be %d before expiresOn. Actual: %v", tokenExpiryDelta, u.expires)
 		}
 	})
 

--- a/auth/providers/azure/graph/graph_test.go
+++ b/auth/providers/azure/graph/graph_test.go
@@ -107,11 +107,12 @@ func TestLogin(t *testing.T) {
 		validBody := `{
   "token_type": "Bearer",
   "expires_in": 3599,
-  "access_token": "%s"
+  "access_token": "%s",
+  "expires_on": %d
 }`
-		ts, u := getAuthServerAndUserInfo(http.StatusOK, fmt.Sprintf(validBody, validToken), "jason", "bourne")
+		expiresOn := time.Now().Add(time.Second * 3599).Unix()
+		ts, u := getAuthServerAndUserInfo(http.StatusOK, fmt.Sprintf(validBody, validToken, expiresOn), "jason", "bourne")
 		defer ts.Close()
-
 		err := u.RefreshToken(ctx, "")
 		if err != nil {
 			t.Errorf("Error when trying to log in: %s", err)

--- a/auth/providers/azure/graph/graph_test.go
+++ b/auth/providers/azure/graph/graph_test.go
@@ -125,7 +125,6 @@ func TestLogin(t *testing.T) {
 		// Normalize to second precision for comparison
 		expectedExpiresOn := expiresOn.Add(-tokenExpiryDelta).Truncate(time.Second)
 		actualExpires := u.expires.Truncate(time.Second)
-		// Expect u.expires to be tokenExpiryDelta before expiresOn
 		if !expectedExpiresOn.Equal(actualExpires) {
 			t.Errorf("Expiry not set properly. Expected it to be %v equal to expiresOn. Actual: %v", expectedExpiresOn, actualExpires)
 		}

--- a/auth/providers/azure/graph/graph_test.go
+++ b/auth/providers/azure/graph/graph_test.go
@@ -122,9 +122,12 @@ func TestLogin(t *testing.T) {
 		if !time.Now().Before(u.expires) {
 			t.Errorf("Expiry not set properly. Expected it to be after the current time. Actual: %v", u.expires)
 		}
+		// Normalize to second precision for comparison
+		expectedExpiresOn := expiresOn.Add(-tokenExpiryDelta).Truncate(time.Second)
+		actualExpires := u.expires.Truncate(time.Second)
 		// Expect u.expires to be tokenExpiryDelta before expiresOn
-		if expiresOn.Add(-tokenExpiryDelta).Equal(u.expires) {
-			t.Errorf("Expiry not set properly. Expected it to be %d before expiresOn. Actual: %v", tokenExpiryDelta, u.expires)
+		if !expectedExpiresOn.Equal(actualExpires) {
+			t.Errorf("Expiry not set properly. Expected it to be %v equal to expiresOn. Actual: %v", expectedExpiresOn, actualExpires)
 		}
 	})
 

--- a/auth/providers/azure/graph/graph_test.go
+++ b/auth/providers/azure/graph/graph_test.go
@@ -106,7 +106,6 @@ func TestLogin(t *testing.T) {
 		validToken := "blackbriar"
 		validBody := `{
   "token_type": "Bearer",
-  "expires_in": 3599,
   "access_token": "%s",
   "expires_on": %d
 }`
@@ -499,7 +498,7 @@ func TestGetGroups(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle("/login", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		_, _ = w.Write([]byte(`{ "token_type": "Bearer", "expires_in": 8459, "access_token": "secret"}`))
+		_, _ = w.Write([]byte(`{ "token_type": "Bearer", "expires_on": 1732881796, "access_token": "secret"}`))
 	}))
 	mux.Handle("/users/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)

--- a/auth/providers/azure/graph/msi_tokenprovider.go
+++ b/auth/providers/azure/graph/msi_tokenprovider.go
@@ -97,7 +97,7 @@ func (u *msiTokenProvider) Acquire(ctx context.Context, token string) (AuthRespo
 
 	authResp.TokenType = tokenResp.TokenType
 	// This value is true only at token creation time, if a cached token is used, its not accurate
-	authResp.Expires, err = strconv.Atoi(tokenResp.ExpiresIn)
+	authResp.ExpiresIn, err = strconv.Atoi(tokenResp.ExpiresIn)
 	if err != nil {
 		return authResp, errors.Wrapf(err, "Failed to decode expires_in field for token")
 	}

--- a/auth/providers/azure/graph/msi_tokenprovider.go
+++ b/auth/providers/azure/graph/msi_tokenprovider.go
@@ -99,7 +99,7 @@ func (u *msiTokenProvider) Acquire(ctx context.Context, token string) (AuthRespo
 	// This value is true only at token creation time, if a cached token is used, its not accurate
 	authResp.Expires, err = strconv.Atoi(tokenResp.ExpiresIn)
 	if err != nil {
-		return authResp, errors.Wrapf(err, "Failed to decode expiry date")
+		return authResp, errors.Wrapf(err, "Failed to decode expires_in field for token")
 	}
 	// This is the actual time the token expires in Unix time
 	authResp.ExpiresOn, err = strconv.Atoi(tokenResp.ExpiresOn)

--- a/auth/providers/azure/graph/msi_tokenprovider.go
+++ b/auth/providers/azure/graph/msi_tokenprovider.go
@@ -96,11 +96,6 @@ func (u *msiTokenProvider) Acquire(ctx context.Context, token string) (AuthRespo
 	}
 
 	authResp.TokenType = tokenResp.TokenType
-	// This value is true only at token creation time, if a cached token is used, its not accurate
-	authResp.ExpiresIn, err = strconv.Atoi(tokenResp.ExpiresIn)
-	if err != nil {
-		return authResp, errors.Wrapf(err, "Failed to decode expires_in field for token")
-	}
 	// This is the actual time the token expires in Unix time
 	authResp.ExpiresOn, err = strconv.Atoi(tokenResp.ExpiresOn)
 	if err != nil {

--- a/auth/providers/azure/graph/msi_tokenprovider.go
+++ b/auth/providers/azure/graph/msi_tokenprovider.go
@@ -96,9 +96,15 @@ func (u *msiTokenProvider) Acquire(ctx context.Context, token string) (AuthRespo
 	}
 
 	authResp.TokenType = tokenResp.TokenType
+	// This value is true only at token creation time, if a cached token is used, its not accurate
 	authResp.Expires, err = strconv.Atoi(tokenResp.ExpiresIn)
 	if err != nil {
 		return authResp, errors.Wrapf(err, "Failed to decode expiry date")
+	}
+	// This is the actual time the token expires in Unix time
+	authResp.ExpiresOn, err = strconv.Atoi(tokenResp.ExpiresOn)
+	if err != nil {
+		return authResp, errors.Wrapf(err, "Failed to decode expires_on field for token")
 	}
 	authResp.Token = tokenResp.AccessToken
 

--- a/auth/providers/azure/graph/msi_tokenprovider_test.go
+++ b/auth/providers/azure/graph/msi_tokenprovider_test.go
@@ -28,7 +28,7 @@ func TestMSITokenProvider(t *testing.T) {
 	const (
 		inputAccessToken    = "inputAccessToken"
 		msiAccessToken      = "msiAccessToken"
-		tokenResponse       = `{"access_token":"%s","expires_in":"86700","refresh_token":"","expires_on":"1732881796","not_before":"1732795096","resource":"https://management.azure.com","token_type":"Bearer"}`
+		tokenResponse       = `{"access_token":"%s","expires_in":"86700","refresh_token":"","expires_on":"1732881796","not_before":"%d","resource":"https://management.azure.com","token_type":"Bearer"}`
 		expectedContentType = "application/json"
 		expectedTokenType   = "Bearer"
 		expectedExpiresOn   = 1732881796
@@ -42,7 +42,7 @@ func TestMSITokenProvider(t *testing.T) {
 			if req.Header.Get("Content-Type") != expectedContentType {
 				t.Errorf("expected content type: %s, actual: %s", expectedContentType, req.Header.Get("Content-Type"))
 			}
-			_, _ = rw.Write([]byte(fmt.Sprintf(tokenResponse, msiAccessToken)))
+			_, _ = rw.Write([]byte(fmt.Sprintf(tokenResponse, msiAccessToken, expectedExpiresOn)))
 		})
 
 		defer stopMSITestServer(t, s)

--- a/auth/providers/azure/graph/msi_tokenprovider_test.go
+++ b/auth/providers/azure/graph/msi_tokenprovider_test.go
@@ -28,7 +28,7 @@ func TestMSITokenProvider(t *testing.T) {
 	const (
 		inputAccessToken    = "inputAccessToken"
 		msiAccessToken      = "msiAccessToken"
-		tokenResponse       = `{"access_token":"%s","expires_in":"86700","refresh_token":"","expires_on":"1732881796","not_before":"%d","resource":"https://management.azure.com","token_type":"Bearer"}`
+		tokenResponse       = `{"access_token":"%s","expires_in":"86700","refresh_token":"","expires_on":"%d","not_before":"1732795096","resource":"https://management.azure.com","token_type":"Bearer"}`
 		expectedContentType = "application/json"
 		expectedTokenType   = "Bearer"
 		expectedExpiresOn   = 1732881796

--- a/auth/providers/azure/graph/msi_tokenprovider_test.go
+++ b/auth/providers/azure/graph/msi_tokenprovider_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 )
 
@@ -32,6 +31,7 @@ func TestMSITokenProvider(t *testing.T) {
 		tokenResponse       = `{"access_token":"%s","expires_in":"86700","refresh_token":"","expires_on":"1732881796","not_before":"1732795096","resource":"https://management.azure.com","token_type":"Bearer"}`
 		expectedContentType = "application/json"
 		expectedTokenType   = "Bearer"
+		expectedExpiresOn   = 1732881796
 	)
 
 	t.Run("Upon Success Response", func(t *testing.T) {
@@ -53,13 +53,6 @@ func TestMSITokenProvider(t *testing.T) {
 		if err != nil {
 			t.Fatalf("refresh should not return error: %s", err)
 		}
-		t.Logf("Response: %v", resp)
-
-		var expectedResp TokenResponse
-		err = json.Unmarshal([]byte(tokenResponse), &expectedResp)
-		if err != nil {
-			t.Fatalf("failed to unmarshal token response: %v", err)
-		}
 
 		if resp.Token != msiAccessToken {
 			t.Errorf("returned obo token '%s' doesn't match expected '%s'", resp.Token, msiAccessToken)
@@ -68,9 +61,8 @@ func TestMSITokenProvider(t *testing.T) {
 			t.Errorf("expected token type: Bearer, actual: %s", resp.TokenType)
 		}
 
-		expectedExpiresOn, _ := strconv.Atoi(expectedResp.ExpiresOn)
 		if resp.ExpiresOn != expectedExpiresOn {
-			t.Errorf("expected expires on: %s, actual: %d", expectedResp.ExpiresOn, resp.ExpiresOn)
+			t.Errorf("expected expires on: %d, actual: %d", expectedExpiresOn, resp.ExpiresOn)
 		}
 	})
 

--- a/auth/providers/azure/graph/obo_tokenprovider_test.go
+++ b/auth/providers/azure/graph/obo_tokenprovider_test.go
@@ -31,7 +31,7 @@ func TestOBOTokenProvider(t *testing.T) {
 		clientID            = "fakeID"
 		clientSecret        = "fakeSecret"
 		scope               = "https://graph.microsoft.com/.default"
-		oboResponse         = `{"token_type":"Bearer","expires_in":3599,"access_token":"%s"}`
+		oboResponse         = `{"token_type":"Bearer","expires_on":1732881796,"access_token":"%s"}`
 		expectedContentType = "application/x-www-form-urlencoded"
 		expectedTokenUse    = "on_behalf_of"
 		expectedGrantType   = "urn:ietf:params:oauth:grant-type:jwt-bearer"

--- a/auth/providers/azure/graph/types.go
+++ b/auth/providers/azure/graph/types.go
@@ -19,7 +19,6 @@ package graph
 // AuthResponse represents a response from the MS Graph auth API
 type AuthResponse struct {
 	TokenType string `json:"token_type"`
-	ExpiresIn int    `json:"expires_in"`
 	Token     string `json:"access_token"`
 	// This is the actual time the token expires on in Unix time
 	ExpiresOn int `json:"expires_on"`

--- a/auth/providers/azure/graph/types.go
+++ b/auth/providers/azure/graph/types.go
@@ -21,7 +21,7 @@ type AuthResponse struct {
 	TokenType string `json:"token_type"`
 	Expires   int    `json:"expires_in"`
 	Token     string `json:"access_token"`
-	// This is the actual time the token expires in Unix time
+	// This is the actual time the token expires on in Unix time
 	ExpiresOn int `json:"expires_on"`
 }
 

--- a/auth/providers/azure/graph/types.go
+++ b/auth/providers/azure/graph/types.go
@@ -21,6 +21,8 @@ type AuthResponse struct {
 	TokenType string `json:"token_type"`
 	Expires   int    `json:"expires_in"`
 	Token     string `json:"access_token"`
+	// This is the actual time the token expires in Unix time
+	ExpiresOn int `json:"expires_on"`
 }
 
 // NOTE: These below are partial implementations of the API objects containing

--- a/auth/providers/azure/graph/types.go
+++ b/auth/providers/azure/graph/types.go
@@ -19,7 +19,7 @@ package graph
 // AuthResponse represents a response from the MS Graph auth API
 type AuthResponse struct {
 	TokenType string `json:"token_type"`
-	Expires   int    `json:"expires_in"`
+	ExpiresIn int    `json:"expires_in"`
 	Token     string `json:"access_token"`
 	// This is the actual time the token expires on in Unix time
 	ExpiresOn int `json:"expires_on"`

--- a/authz/providers/azure/azure_test.go
+++ b/authz/providers/azure/azure_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	loginResp            = `{ "token_type": "Bearer", "expires_in": 8459, "access_token": "%v"}`
+	loginResp            = `{ "token_type": "Bearer", "expires_on": 1732881796, "access_token": "%v"}`
 	httpClientRetryCount = 2
 )
 

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -55,7 +55,7 @@ const (
 	checkAccessPath            = "/providers/Microsoft.Authorization/checkaccess"
 	checkAccessAPIVersion      = "2018-09-01-preview"
 	remainingSubReadARMHeader  = "x-ms-ratelimit-remaining-subscription-reads"
-	expiryDelta                = 60 * time.Second
+	tokenExpiryDelta           = 300 * time.Second
 	checkaccessContextTimeout  = 23 * time.Second
 	correlationRequestIDHeader = "x-ms-correlation-request-id"
 )
@@ -227,7 +227,7 @@ func (a *AccessInfo) RefreshToken(ctx context.Context) error {
 
 		// Use ExpiresOn to set the expiration time
 		expOn := time.Unix(int64(resp.ExpiresOn), 0)
-		a.expiresAt = expOn.Add(-expiryDelta)
+		a.expiresAt = expOn.Add(-tokenExpiryDelta)
 		klog.Infof("Token refreshed successfully at %s. Expire at set to: %s", time.Now(), a.expiresAt)
 	}
 

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -224,9 +224,11 @@ func (a *AccessInfo) RefreshToken(ctx context.Context) error {
 
 		// Set the authorization headers for future requests
 		a.headers.Set("Authorization", fmt.Sprintf("Bearer %s", resp.Token))
-		expIn := time.Duration(resp.Expires) * time.Second
-		a.expiresAt = time.Now().Add(expIn - expiryDelta)
-		klog.Infof("Token refreshed successfully on %s. Expire at:%s", time.Now(), a.expiresAt)
+
+		// Use ExpiresOn to set the expiration time
+		expOn := time.Unix(int64(resp.ExpiresOn), 0)
+		a.expiresAt = expOn.Add(-expiryDelta)
+		klog.Infof("Token refreshed successfully on %s. Expire at: %s", time.Now(), a.expiresAt)
 	}
 
 	return nil

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -49,12 +49,13 @@ import (
 )
 
 const (
-	managedClusters            = "Microsoft.ContainerService/managedClusters"
-	fleets                     = "Microsoft.ContainerService/fleets"
-	connectedClusters          = "Microsoft.Kubernetes/connectedClusters"
-	checkAccessPath            = "/providers/Microsoft.Authorization/checkaccess"
-	checkAccessAPIVersion      = "2018-09-01-preview"
-	remainingSubReadARMHeader  = "x-ms-ratelimit-remaining-subscription-reads"
+	managedClusters           = "Microsoft.ContainerService/managedClusters"
+	fleets                    = "Microsoft.ContainerService/fleets"
+	connectedClusters         = "Microsoft.Kubernetes/connectedClusters"
+	checkAccessPath           = "/providers/Microsoft.Authorization/checkaccess"
+	checkAccessAPIVersion     = "2018-09-01-preview"
+	remainingSubReadARMHeader = "x-ms-ratelimit-remaining-subscription-reads"
+	// Time delta to refresh token before expiry
 	tokenExpiryDelta           = 300 * time.Second
 	checkaccessContextTimeout  = 23 * time.Second
 	correlationRequestIDHeader = "x-ms-correlation-request-id"

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -228,7 +228,7 @@ func (a *AccessInfo) RefreshToken(ctx context.Context) error {
 		// Use ExpiresOn to set the expiration time
 		expOn := time.Unix(int64(resp.ExpiresOn), 0)
 		a.expiresAt = expOn.Add(-expiryDelta)
-		klog.Infof("Token refreshed successfully on %s. Expire at: %s", time.Now(), a.expiresAt)
+		klog.Infof("Token refreshed successfully at %s. Expire at set to: %s", time.Now(), a.expiresAt)
 	}
 
 	return nil

--- a/authz/providers/azure/rbac/rbac_test.go
+++ b/authz/providers/azure/rbac/rbac_test.go
@@ -178,9 +178,11 @@ func TestLogin(t *testing.T) {
 		validBody := `{
 							"token_type": "Bearer",
 							"expires_in": 3599,
-							"access_token": "%s"
+							"access_token": "%s",
+							"expires_on": %d
 						}`
-		ts, u := getAuthServerAndAccessInfo(http.StatusOK, fmt.Sprintf(validBody, validToken), "jason", "bourne")
+		expiresOn := time.Now().Add(time.Second * 3599).Unix()
+		ts, u := getAuthServerAndAccessInfo(http.StatusOK, fmt.Sprintf(validBody, validToken, expiresOn), "jason", "bourne")
 		defer ts.Close()
 
 		ctx := context.Background()

--- a/authz/providers/azure/rbac/rbac_test.go
+++ b/authz/providers/azure/rbac/rbac_test.go
@@ -195,9 +195,13 @@ func TestLogin(t *testing.T) {
 		if !time.Now().Before(u.expiresAt) {
 			t.Errorf("Expiry not set properly. Expected it to be after the current time. Actual: %v", u.expiresAt)
 		}
+
+		// Normalize to second precision for comparison
+		expectedExpiresOn := expiresOn.Add(-tokenExpiryDelta).Truncate(time.Second)
+		actualExpires := u.expiresAt.Truncate(time.Second)
 		// Expect u.expires to be tokenExpiryDelta before expiresOn
-		if expiresOn.Add(-tokenExpiryDelta).Equal(u.expiresAt) {
-			t.Errorf("Expiry not set properly. Expected it to be %d before expiresOn. Actual: %v", tokenExpiryDelta, u.expiresAt)
+		if !expectedExpiresOn.Equal(actualExpires) {
+			t.Errorf("Expiry not set properly. Expected it to be %v equal to expiresOn. Actual: %v", expectedExpiresOn, actualExpires)
 		}
 	})
 

--- a/authz/providers/azure/rbac/rbac_test.go
+++ b/authz/providers/azure/rbac/rbac_test.go
@@ -177,7 +177,6 @@ func TestLogin(t *testing.T) {
 		validToken := "blackbriar"
 		validBody := `{
 							"token_type": "Bearer",
-							"expires_in": 3599,
 							"access_token": "%s",
 							"expires_on": %d
 						}`

--- a/authz/providers/azure/rbac/rbac_test.go
+++ b/authz/providers/azure/rbac/rbac_test.go
@@ -199,7 +199,6 @@ func TestLogin(t *testing.T) {
 		// Normalize to second precision for comparison
 		expectedExpiresOn := expiresOn.Add(-tokenExpiryDelta).Truncate(time.Second)
 		actualExpires := u.expiresAt.Truncate(time.Second)
-		// Expect u.expires to be tokenExpiryDelta before expiresOn
 		if !expectedExpiresOn.Equal(actualExpires) {
 			t.Errorf("Expiry not set properly. Expected it to be %v equal to expiresOn. Actual: %v", expectedExpiresOn, actualExpires)
 		}

--- a/authz/providers/azure/rbac/rbac_test.go
+++ b/authz/providers/azure/rbac/rbac_test.go
@@ -181,8 +181,8 @@ func TestLogin(t *testing.T) {
 							"access_token": "%s",
 							"expires_on": %d
 						}`
-		expiresOn := time.Now().Add(time.Second * 3599).Unix()
-		ts, u := getAuthServerAndAccessInfo(http.StatusOK, fmt.Sprintf(validBody, validToken, expiresOn), "jason", "bourne")
+		expiresOn := time.Now().Add(time.Second * 3599)
+		ts, u := getAuthServerAndAccessInfo(http.StatusOK, fmt.Sprintf(validBody, validToken, expiresOn.Unix()), "jason", "bourne")
 		defer ts.Close()
 
 		ctx := context.Background()
@@ -195,6 +195,10 @@ func TestLogin(t *testing.T) {
 		}
 		if !time.Now().Before(u.expiresAt) {
 			t.Errorf("Expiry not set properly. Expected it to be after the current time. Actual: %v", u.expiresAt)
+		}
+		// Expect u.expires to be tokenExpiryDelta before expiresOn
+		if expiresOn.Add(-tokenExpiryDelta).Equal(u.expiresAt) {
+			t.Errorf("Expiry not set properly. Expected it to be %d before expiresOn. Actual: %v", tokenExpiryDelta, u.expiresAt)
 		}
 	})
 


### PR DESCRIPTION
This PR aims to fix the refresh token logic for Azure RBAC.
The existing refresh token logic relies on the `expires_in` value from the token response -
{"access_token":"<toeken>","expires_in":"86700","refresh_token":"","expires_on":"1732881796","not_before":"1732795096","resource":"https://management.azure.com","token_type":"Bearer"}
However in the case when the token is not fresh and returned from cache, the `expires_in` value misleads Guard to think the token doesn't need refreshing since it adds the current_time + expires_in to set the new expiry time.
In this PR we directly use the `expires_on` to set the expiry time accurately.

The PR also increases the tokenExpiryDelta to 5 minutes to ensure the token is refreshed 5 mins earlier than actual expiry. This is done on both AuthZ (rbac.go) and AuthN (graph.go) flow.

Removed `expires_in` to be returned from msi_adapter in favor of `expires_on`

Using the current implementation guard now sets the expires property correctly, i.e. knows it expires at 2024-11-29 21:05:56 +0000 UTC in the below example rather than doing - current-time + 86700 

Guard log - 
```
│ I1202 20:38:40.019063       1 graph.go:331] Token received with expires_in 86700 and expires_at 1733258179            

││ I1202 20:38:40.019114       1 graph.go:337] Token refreshed successfully at 2024-12-02 20:38:40.019110448 +0000 UTC m=+444.823514368. Expire at set to: 2024-12-03 20:31:19 +0000 UTC 
 ```
 
 Tested KAP flow - 
 
![image](https://github.com/user-attachments/assets/fa27d744-e180-47e5-ac1a-1ea34104b7d7)

RBAC non proxy flow - 
![image](https://github.com/user-attachments/assets/0e0266a4-fc4f-4e8d-b895-b3dc12768b13)


 