### PR TITLE
docs: record DataAction registry invariant for CheckAccess mapping changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Publish to GitHub Container Registry
         env:
-          REGISTRY: ghcr.io/kubeguard
+          REGISTRY: ghcr.io/Azure
           APPSCODE_ENV: prod
         run: |
           make release COMPRESS=yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,10 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Print version info
         id: semver
@@ -44,10 +47,17 @@ jobs:
         run: |
           make release COMPRESS=yes
 
+      - name: Determine tag
+        id: tag
+        run: |
+          TAG=$(git describe --exact-match --abbrev=0 2>/dev/null || echo "")
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        if: steps.tag.outputs.tag != ''
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
           files: |
             bin/guard-darwin-amd64.tar.gz
             bin/guard-linux-amd64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -26,15 +26,15 @@ jobs:
           make version
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           cache-image: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -54,7 +54,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         if: steps.tag.outputs.tag != ''
         with:
           tag_name: ${{ steps.tag.outputs.tag }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,53 @@ Do NOT commit if any check fails.
 - **Client cert**: `-o Azure` org required for mTLS
 - **Base image for testing**: Use `alpine:3.20` not `distroless/static` - needs CA certificates
 - **Azure SDK**: `BearerTokenPolicy` requires HTTPS for auth tokens
+- **DataAction strings**: Guard does not own the action namespace. Every action it emits
+  must already be published by the resource provider, or it is deniable but not
+  grantable (see below)
+- **`system:` users skip Azure RBAC entirely**: `authz/providers/azure/azure.go` returns
+  NoOpinion for any user whose name starts with `system:`, so node and controller
+  identities on a standard AKS cluster never reach the DataAction mapping
+
+## Changing the DataAction Mapping
+
+`getResourceAndAction` / `getDataActions` in
+`authz/providers/azure/rbac/checkaccessreqhelper.go` compose the DataAction strings that
+Azure RBAC evaluates. A string Guard invents is only authorizable if the RP already
+publishes the matching operation.
+
+**Verify every new action before merging:**
+
+```bash
+az provider operation show --namespace Microsoft.ContainerService -o json \
+  | jq -r '.. | objects | select(.name? // "" | test("<action-suffix>")) | .name'
+```
+
+If the action is absent, the change is breaking and there is no customer-side fix:
+
+- ARM rejects it in custom role definitions with `InvalidDataActionOrNotDataAction -
+  does not match any of the actions supported by the providers`, so it cannot be
+  granted explicitly.
+- Built-in `Azure Kubernetes Service RBAC Reader` and `Writer` enumerate leaf actions,
+  so they do not match it either. Only wildcard-bearing roles match
+  (`managedClusters/*`, `pods/*`, `<resource>/*`), i.e. Admin and Cluster Admin.
+- Net effect: denied for every principal on a least-privilege role, remediable only by
+  widening the role to a wildcard. The RP operations manifest must ship first.
+
+Registered as of 2026-08-13: `managedClusters/pods/{read,write,delete}`,
+`managedClusters/pods/exec/action`,
+`managedClusters/certificates.k8s.io/certificatesigningrequests/{read,write,delete}`.
+NOT registered: `pods/{attach,portforward,proxy}/action`, `services/proxy/action`,
+`nodes/proxy/action`, `certificatesigningrequests/nodeclient/action`.
+
+Two things that make this easy to miss in review:
+
+- **A passing unit test proves nothing here.** Asserting the composed string succeeds
+  whether or not Azure can grant it. Pair every mapping change with the `az` check.
+- **Standard clusters cannot reproduce it.** Splitting a subresource out of its parent
+  action flips previously-allowed requests to denied, but only for principals that
+  actually reach the mapping. Clusters whose kubelets authenticate with an Entra ID
+  identity instead of a bootstrap token are the ones that break; `system:`-prefixed
+  identities mask the regression everywhere else.
 
 ## Commands
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+<!-- BEGIN MICROSOFT SECURITY.MD V1.0.0 BLOCK -->
+
+## Security
+
+Microsoft takes the security of our software products and services seriously, which
+includes all source code repositories in our GitHub organizations.
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting information, locations, contact information, and policies,
+please review the latest guidance for Microsoft repositories at
+[https://aka.ms/SECURITY.md](https://aka.ms/SECURITY.md).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/authz/providers/azure/options/options.go
+++ b/authz/providers/azure/options/options.go
@@ -180,14 +180,6 @@ func (o *Options) Validate(azure azure.Options) []error {
 		errs = append(errs, errors.New("azure.pdp-scope must be non-empty when azure.use-checkaccess-v2 is enabled (e.g., https://authorization.azure.net/.default)"))
 	}
 
-	if o.PDPEndpoint != "" && !o.UseCheckAccessV2 {
-		errs = append(errs, errors.New("azure.use-checkaccess-v2 must be enabled when azure.pdp-endpoint is specified"))
-	}
-
-	if o.PDPScope != "" && !o.UseCheckAccessV2 {
-		errs = append(errs, errors.New("azure.use-checkaccess-v2 must be enabled when azure.pdp-scope is specified"))
-	}
-
 	if o.CacheSizeMB < minCacheSizeMB || o.CacheSizeMB > maxCacheSizeMB {
 		errs = append(errs, fmt.Errorf("azure.cache-size-mb must be between %d and %d", minCacheSizeMB, maxCacheSizeMB))
 	}

--- a/authz/providers/azure/rbac/checkaccess_v2.go
+++ b/authz/providers/azure/rbac/checkaccess_v2.go
@@ -66,7 +66,7 @@ import (
 func (a *AccessInfo) performCheckAccessV2(
 	ctx context.Context,
 	resourceId string,
-	actions []string,
+	actions []azureutils.AuthorizationActionInfo,
 	userOid string,
 	groups []string,
 ) (*authzv1.SubjectAccessReviewStatus, error) {
@@ -124,13 +124,7 @@ func (a *AccessInfo) performCheckAccessV2(
 // buildAuthorizationRequestV2 constructs a CheckAccess v2 AuthorizationRequest.
 // This replaces the SDK's CreateAuthorizationRequest which expects JWT claims.
 // For AKS/Guard, the user identity (oid, groups) comes from SubjectAccessReviewSpec.
-func buildAuthorizationRequestV2(resourceId string, actions []string, userOid string, groups []string) checkaccess.AuthorizationRequest {
-	// Build action info list
-	actionInfos := make([]checkaccess.ActionInfo, len(actions))
-	for i, action := range actions {
-		actionInfos[i] = checkaccess.ActionInfo{Id: action}
-	}
-
+func buildAuthorizationRequestV2(resourceId string, actions []azureutils.AuthorizationActionInfo, userOid string, groups []string) checkaccess.AuthorizationRequest {
 	// Build subject attributes with oid and groups
 	subjectAttrs := checkaccess.SubjectAttributes{
 		ObjectId: userOid,
@@ -143,11 +137,39 @@ func buildAuthorizationRequestV2(resourceId string, actions []string, userOid st
 		Subject: checkaccess.SubjectInfo{
 			Attributes: subjectAttrs,
 		},
-		Actions: actionInfos,
+		Actions: toActionInfos(actions),
 		Resource: checkaccess.ResourceInfo{
 			Id: resourceId,
 		},
 	}
+}
+
+// toActionInfos converts internal AuthorizationActionInfo values to the SDK's
+// ActionInfo type. It preserves IsDataAction (Kubernetes RBAC actions are data
+// actions, and PDP denies them when this is false) and any subresource attributes.
+func toActionInfos(actions []azureutils.AuthorizationActionInfo) []checkaccess.ActionInfo {
+	actionInfos := make([]checkaccess.ActionInfo, len(actions))
+	for i, action := range actions {
+		actionInfos[i] = checkaccess.ActionInfo{
+			Id:           action.Id,
+			IsDataAction: action.IsDataAction,
+			Attributes:   toSDKAttributes(action.Attributes),
+		}
+	}
+	return actionInfos
+}
+
+// toSDKAttributes converts a map[string]string to the SDK's Attributes type
+// (map[string]interface{}), returning nil for an empty map.
+func toSDKAttributes(attrs map[string]string) checkaccess.Attributes {
+	if len(attrs) == 0 {
+		return nil
+	}
+	out := make(checkaccess.Attributes, len(attrs))
+	for key, value := range attrs {
+		out[key] = value
+	}
+	return out
 }
 
 // convertV2ResponseToStatus converts CheckAccess v2 AuthorizationDecision responses
@@ -344,22 +366,13 @@ func (a *AccessInfo) checkAccessV2(ctx context.Context, request *authzv1.Subject
 	return status, nil
 }
 
-// getDataActionsV2 converts SubjectAccessReviewSpec to a list of action IDs for v2 API.
-// This extracts the action ID portion from the v1 AuthorizationActionInfo.
-func getDataActionsV2(ctx context.Context, request *authzv1.SubjectAccessReviewSpec, clusterType string, allowCustomResourceTypeCheck bool, allowSubresourceTypeCheck bool) ([]string, error) {
-	// Reuse v1 logic to get actions
-	authInfoList, err := getDataActions(ctx, request, clusterType, allowCustomResourceTypeCheck, allowSubresourceTypeCheck)
-	if err != nil {
-		return nil, err
-	}
-
-	// Extract action IDs
-	actions := make([]string, len(authInfoList))
-	for i, authInfo := range authInfoList {
-		actions[i] = authInfo.AuthorizationEntity.Id
-	}
-
-	return actions, nil
+// getDataActionsV2 builds the list of authorization actions for the v2 API.
+// It returns the full AuthorizationActionInfo (not just the action IDs) so that
+// IsDataAction and any subresource attributes are preserved for the PDP request
+// (see buildAuthorizationRequestV2 / toActionInfos). Dropping IsDataAction makes
+// PDP evaluate Kubernetes RBAC actions as management actions and deny every check.
+func getDataActionsV2(ctx context.Context, request *authzv1.SubjectAccessReviewSpec, clusterType string, allowCustomResourceTypeCheck bool, allowSubresourceTypeCheck bool) ([]azureutils.AuthorizationActionInfo, error) {
+	return getDataActions(ctx, request, clusterType, allowCustomResourceTypeCheck, allowSubresourceTypeCheck)
 }
 
 // buildResourceIDForV2 constructs and validates a resource ID for CheckAccess v2 API.

--- a/authz/providers/azure/rbac/checkaccess_v2_test.go
+++ b/authz/providers/azure/rbac/checkaccess_v2_test.go
@@ -36,6 +36,8 @@ import (
 	"errors"
 	"testing"
 
+	azureutils "go.kubeguard.dev/guard/util/azure"
+
 	checkaccess "github.com/Azure/checkaccess-v2-go-sdk/client"
 	"github.com/stretchr/testify/assert"
 	authzv1 "k8s.io/api/authorization/v1"
@@ -43,6 +45,15 @@ import (
 
 // testUserOid is a valid UUID used consistently across v2 tests
 const testUserOid = "12345678-1234-1234-1234-123456789abc"
+
+// dataAction builds an AuthorizationActionInfo for a data-plane action - the common
+// case for Kubernetes RBAC checks - used across the v2 request-building tests.
+func dataAction(id string) azureutils.AuthorizationActionInfo {
+	return azureutils.AuthorizationActionInfo{
+		AuthorizationEntity: azureutils.AuthorizationEntity{Id: id},
+		IsDataAction:        true,
+	}
+}
 
 // mockPDPClient is a mock implementation of checkaccess.RemotePDPClient for testing
 type mockPDPClient struct {
@@ -191,7 +202,7 @@ func TestExtractUserIdentityV2_InvalidOid(t *testing.T) {
 
 func TestBuildAuthorizationRequestV2(t *testing.T) {
 	resourceId := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster"
-	actions := []string{"action1", "action2"}
+	actions := []azureutils.AuthorizationActionInfo{dataAction("action1"), dataAction("action2")}
 	userOid := testUserOid
 	groups := []string{"group1", "group2"}
 
@@ -203,12 +214,31 @@ func TestBuildAuthorizationRequestV2(t *testing.T) {
 	assert.Len(t, authzReq.Actions, 2)
 	assert.Equal(t, "action1", authzReq.Actions[0].Id)
 	assert.Equal(t, "action2", authzReq.Actions[1].Id)
+	// Regression: Kubernetes RBAC actions must be sent as data actions. If IsDataAction
+	// is false, PDP evaluates them as management actions and denies every request.
+	assert.True(t, authzReq.Actions[0].IsDataAction)
+	assert.True(t, authzReq.Actions[1].IsDataAction)
 }
 
 func TestBuildAuthorizationRequestV2_EmptyGroups(t *testing.T) {
-	authzReq := buildAuthorizationRequestV2("/resource", []string{"action"}, "oid", nil)
+	authzReq := buildAuthorizationRequestV2("/resource", []azureutils.AuthorizationActionInfo{dataAction("action")}, "oid", nil)
 
 	assert.Nil(t, authzReq.Subject.Attributes.Groups)
+}
+
+func TestBuildAuthorizationRequestV2_PreservesAttributes(t *testing.T) {
+	actions := []azureutils.AuthorizationActionInfo{
+		{
+			AuthorizationEntity: azureutils.AuthorizationEntity{Id: "Microsoft.ContainerService/managedClusters/pods/logs/read"},
+			IsDataAction:        true,
+			Attributes:          map[string]string{SubresourceAttrName: "pods/logs"},
+		},
+	}
+
+	authzReq := buildAuthorizationRequestV2("/resource", actions, "oid", nil)
+
+	assert.True(t, authzReq.Actions[0].IsDataAction)
+	assert.Equal(t, "pods/logs", authzReq.Actions[0].Attributes[SubresourceAttrName])
 }
 
 func TestGetDataActionsV2_Success(t *testing.T) {
@@ -225,8 +255,9 @@ func TestGetDataActionsV2_Success(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, actions)
-	assert.Contains(t, actions[0], "pods")
-	assert.Contains(t, actions[0], "read")
+	assert.Contains(t, actions[0].Id, "pods")
+	assert.Contains(t, actions[0].Id, "read")
+	assert.True(t, actions[0].IsDataAction)
 }
 
 func TestPerformCheckAccessV2_Success(t *testing.T) {
@@ -235,6 +266,8 @@ func TestPerformCheckAccessV2_Success(t *testing.T) {
 			// Verify the request was built correctly
 			assert.Equal(t, testUserOid, authzReq.Subject.Attributes.ObjectId)
 			assert.Equal(t, []string{"group1"}, authzReq.Subject.Attributes.Groups)
+			// Regression: actions must be sent as data actions, else PDP denies them.
+			assert.True(t, authzReq.Actions[0].IsDataAction)
 
 			return &checkaccess.AuthorizationDecisionResponse{
 				Value: []checkaccess.AuthorizationDecision{
@@ -256,7 +289,7 @@ func TestPerformCheckAccessV2_Success(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	actions := []string{"Microsoft.ContainerService/managedClusters/pods/read"}
+	actions := []azureutils.AuthorizationActionInfo{dataAction("Microsoft.ContainerService/managedClusters/pods/read")}
 	userOid := testUserOid
 	groups := []string{"group1"}
 	status, err := accessInfo.performCheckAccessV2(ctx, "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster", actions, userOid, groups)
@@ -269,9 +302,9 @@ func TestPerformCheckAccessV2_Success(t *testing.T) {
 
 func TestPerformCheckAccessV2_BatchingMultipleBatches(t *testing.T) {
 	// Create 250 actions to test batching (should create 2 batches: 200 + 50)
-	actions := make([]string, 250)
+	actions := make([]azureutils.AuthorizationActionInfo, 250)
 	for i := 0; i < 250; i++ {
-		actions[i] = "Microsoft.ContainerService/managedClusters/action"
+		actions[i] = dataAction("Microsoft.ContainerService/managedClusters/action")
 	}
 
 	callCount := 0
@@ -325,7 +358,7 @@ func TestPerformCheckAccessV2_CheckAccessError(t *testing.T) {
 	ctx := context.Background()
 	userOid := testUserOid
 	groups := []string{"group1"}
-	status, err := accessInfo.performCheckAccessV2(ctx, "/resource", []string{"action"}, userOid, groups)
+	status, err := accessInfo.performCheckAccessV2(ctx, "/resource", []azureutils.AuthorizationActionInfo{dataAction("action")}, userOid, groups)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "CheckAccess v2 batch failed")

--- a/authz/providers/azure/rbac/checkaccessreqhelper.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper.go
@@ -226,6 +226,8 @@ func getActionName(verb string) string {
 		return "use/action"
 	case "impersonate":
 		return "impersonate/action"
+	case "inference":
+		return "inference/action"
 
 	case "create":
 		fallthrough // instead of action create will be mapped to write

--- a/authz/providers/azure/rbac/checkaccessreqhelper.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper.go
@@ -840,3 +840,44 @@ func buildCheckAccessURL(
 
 	return rv.String(), nil
 }
+
+// buildCheckAccessV2URL composes the full PDP CheckAccess v2 request URL from a
+// regional PDP endpoint (for example "https://westcentralus.authorization.azure.net").
+//
+// The checkaccess-v2-go-sdk POSTs directly to the endpoint with no path
+// manipulation, so the checkAccess path and api-version must already be present in
+// the URL handed to the SDK. A bare regional host returns a non-JSON 404 that the
+// SDK then fails to decode ("invalid character ..."), so composing the URL here is
+// required for v2 to function.
+//
+// If endpoint already targets the checkAccess path (for example a fully-formed URL
+// supplied for testing) it is returned unchanged. A non-empty apiVersion overrides
+// defaultCheckAccessV2APIVersion.
+func buildCheckAccessV2URL(endpoint, apiVersion string) (string, error) {
+	if strings.TrimSpace(endpoint) == "" {
+		return "", fmt.Errorf("PDP endpoint must not be empty")
+	}
+
+	rv, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid PDP endpoint %q: %w", endpoint, err)
+	}
+	if !strings.EqualFold(rv.Scheme, "https") {
+		return "", fmt.Errorf("invalid PDP endpoint scheme %q, expected https", rv.Scheme)
+	}
+
+	// Endpoint already targets the checkAccess path: treat it as fully formed.
+	if strings.HasSuffix(strings.ToLower(strings.TrimRight(rv.Path, "/")), strings.ToLower(checkAccessPath)) {
+		return endpoint, nil
+	}
+
+	if apiVersion == "" {
+		apiVersion = defaultCheckAccessV2APIVersion
+	}
+	rv.Path = path.Join(rv.Path, checkAccessPath)
+	params := rv.Query()
+	params.Set(queryParamAPIVersion, apiVersion)
+	rv.RawQuery = params.Encode()
+
+	return rv.String(), nil
+}

--- a/authz/providers/azure/rbac/checkaccessreqhelper.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper.go
@@ -49,6 +49,7 @@ const (
 	NonAADUserNotAllowedVerdict = "Access denied by Azure RBAC for non AAD users. Configure --azure.skip-authz-for-non-aad-users to enable access. If you are an AAD user, please set Extra:oid parameter for impersonated user in the kubeconfig."
 	CheckAccessErrorVerdict     = "Access denied due to Azure RBAC check failure. Please retry later."
 	PodsResource                = "pods"
+	CSRResource                 = "certificatesigningrequests"
 	CustomResources             = "customresources"
 	ReadVerb                    = "read"
 	WriteVerb                   = "write"
@@ -246,16 +247,35 @@ func getActionName(verb string) string {
 	}
 }
 
+// securitySensitiveSubresources lists resource/subresource pairs where the
+// subresource represents a distinct authorization gate in upstream Kubernetes
+// and MUST be preserved in the DataAction string rather than collapsed into
+// the base resource action. Each entry produces "<resource>/<subresource>/action"
+// instead of "<resource>/write".
+//
+// pods/exec: exec into a container is a fundamentally different privilege than
+// creating a pod; the DataAction must remain pods/exec/action.
+//
+// certificatesigningrequests/nodeclient: the upstream csrapprover issues a SAR
+// with this subresource to gate kubelet CSR auto-approval. Collapsing it into
+// certificatesigningrequests/write allows any principal with CSR-write to get a
+// signed kubelet certificate (MSRC 119438).
+var securitySensitiveSubresources = map[string]map[string]struct{}{
+	PodsResource: {
+		"exec": {},
+	},
+	CSRResource: {
+		"nodeclient": {},
+	},
+}
+
 func getResourceAndAction(resource string, subResource string, verb string) string {
-	var action string
-
-	if resource == PodsResource && subResource == "exec" {
-		action = path.Join(resource, subResource, "action")
-	} else {
-		action = path.Join(resource, getActionName(verb))
+	if subs, ok := securitySensitiveSubresources[resource]; ok && subResource != "" {
+		if _, sensitive := subs[subResource]; sensitive {
+			return path.Join(resource, subResource, "action")
+		}
 	}
-
-	return action
+	return path.Join(resource, getActionName(verb))
 }
 
 func getDataActions(ctx context.Context, subRevReq *authzv1.SubjectAccessReviewSpec, clusterType string, allowCustomResourceTypeCheck bool, allowSubresourceTypeCheck bool) ([]azureutils.AuthorizationActionInfo, error) {

--- a/authz/providers/azure/rbac/checkaccessreqhelper.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper.go
@@ -874,7 +874,7 @@ func buildCheckAccessV2URL(endpoint, apiVersion string) (string, error) {
 	if apiVersion == "" {
 		apiVersion = defaultCheckAccessV2APIVersion
 	}
-	rv.Path = path.Join(rv.Path, checkAccessPath)
+	rv = rv.JoinPath(checkAccessPath)
 	params := rv.Query()
 	params.Set(queryParamAPIVersion, apiVersion)
 	rv.RawQuery = params.Encode()

--- a/authz/providers/azure/rbac/checkaccessreqhelper.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper.go
@@ -311,7 +311,10 @@ func getDataActions(ctx context.Context, subRevReq *authzv1.SubjectAccessReviewS
 
 		} else {
 			if len(storedOperationsMap) == 0 {
-				return nil, fmt.Errorf("Wildcard support for Resource/Verb/Group is not enabled for request Group: %s, Resource: %s, Verb: %s", subRevReq.ResourceAttributes.Group, subRevReq.ResourceAttributes.Resource, subRevReq.ResourceAttributes.Verb)
+				return nil, errutils.WithCode(
+					fmt.Errorf("wildcard resource/verb/group check unavailable: operations map not populated (Group: %s, Resource: %s, Verb: %s)",
+						subRevReq.ResourceAttributes.Group, subRevReq.ResourceAttributes.Resource, subRevReq.ResourceAttributes.Verb),
+					http.StatusBadRequest)
 			}
 
 			authInfoList, err = getAuthInfoListForWildcard(ctx, subRevReq, storedOperationsMap, clusterType, isCustomerResourceTypeCheckAvailable, allowSubresourceTypeCheck)

--- a/authz/providers/azure/rbac/checkaccessreqhelper_test.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper_test.go
@@ -306,6 +306,17 @@ func Test_getDataActions(t *testing.T) {
 		},
 
 		{
+			"aimanager-inference",
+			args{
+				isWildcardTest: false,
+				subRevReq: &authzv1.SubjectAccessReviewSpec{
+					ResourceAttributes: &authzv1.ResourceAttributes{Group: "", Resource: "namespaces", Version: "v1", Name: "test", Verb: "inference"},
+				}, clusterType: "Microsoft.ContainerService/aiManagers",
+			},
+			[]azureutils.AuthorizationActionInfo{{AuthorizationEntity: azureutils.AuthorizationEntity{Id: "Microsoft.ContainerService/aiManagers/namespaces/inference/action"}, IsDataAction: true}},
+		},
+
+		{
 			"arc5",
 			args{
 				isWildcardTest: false,

--- a/authz/providers/azure/rbac/checkaccessreqhelper_test.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper_test.go
@@ -393,6 +393,44 @@ func Test_getDataActions(t *testing.T) {
 			[]azureutils.AuthorizationActionInfo{{AuthorizationEntity: azureutils.AuthorizationEntity{Id: "fleet/pods/exec/action"}, IsDataAction: true}},
 		},
 
+		// CSR nodeclient subresource must produce a distinct DataAction
+		// so that bare certificatesigningrequests/write does NOT satisfy
+		// the SAR for kubelet CSR approval (MSRC 119438).
+		{
+			"csrNodeclientAKS",
+			args{
+				isWildcardTest: false,
+				subRevReq: &authzv1.SubjectAccessReviewSpec{
+					ResourceAttributes: &authzv1.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Subresource: "nodeclient", Version: "v1", Name: "", Verb: "create"},
+				}, clusterType: aksClusterType,
+			},
+			[]azureutils.AuthorizationActionInfo{{AuthorizationEntity: azureutils.AuthorizationEntity{Id: "aks/certificates.k8s.io/certificatesigningrequests/nodeclient/action"}, IsDataAction: true}},
+		},
+
+		{
+			"csrNodeclientFleet",
+			args{
+				isWildcardTest: false,
+				subRevReq: &authzv1.SubjectAccessReviewSpec{
+					ResourceAttributes: &authzv1.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Subresource: "nodeclient", Version: "v1", Name: "", Verb: "create"},
+				}, clusterType: "fleet",
+			},
+			[]azureutils.AuthorizationActionInfo{{AuthorizationEntity: azureutils.AuthorizationEntity{Id: "fleet/certificates.k8s.io/certificatesigningrequests/nodeclient/action"}, IsDataAction: true}},
+		},
+
+		// CSR with a non-sensitive subresource (e.g. approval, status)
+		// should still collapse to the base action, not preserve the subresource.
+		{
+			"csrApprovalSubresourceStillCollapsed",
+			args{
+				isWildcardTest: false,
+				subRevReq: &authzv1.SubjectAccessReviewSpec{
+					ResourceAttributes: &authzv1.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Subresource: "approval", Version: "v1", Name: "test", Verb: "update"},
+				}, clusterType: aksClusterType,
+			},
+			[]azureutils.AuthorizationActionInfo{{AuthorizationEntity: azureutils.AuthorizationEntity{Id: "aks/certificates.k8s.io/certificatesigningrequests/write"}, IsDataAction: true}},
+		},
+
 		{
 			"allStar",
 			args{

--- a/authz/providers/azure/rbac/checkaccessreqhelper_test.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper_test.go
@@ -65,6 +65,17 @@ func createOperationsMap(clusterType string) azureutils.OperationsMap {
 	}
 }
 
+// setStoredOperationsMap overrides the package-level getStoredOperationsMap seam
+// for the duration of the test and restores it on cleanup. getStoredOperationsMap
+// is package state; a test that mutates it without restoring leaks its setup into
+// later tests (in source order), making outcomes order-dependent.
+func setStoredOperationsMap(t *testing.T, m azureutils.OperationsMap) {
+	t.Helper()
+	prev := getStoredOperationsMap
+	t.Cleanup(func() { getStoredOperationsMap = prev })
+	getStoredOperationsMap = func() azureutils.OperationsMap { return m }
+}
+
 func Test_getScope(t *testing.T) {
 	type args struct {
 		resourceId                      string
@@ -659,10 +670,7 @@ func Test_getDataActions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			operationsMap := createOperationsMap(tt.args.clusterType)
-			getStoredOperationsMap = func() azureutils.OperationsMap {
-				return operationsMap
-			}
+			setStoredOperationsMap(t, createOperationsMap(tt.args.clusterType))
 
 			ctx := context.Background()
 			got, _ := getDataActions(ctx, tt.args.subRevReq, tt.args.clusterType, tt.args.isCrTest, tt.args.isSubresTest)
@@ -704,9 +712,7 @@ func Test_getDataActions(t *testing.T) {
 }
 
 func Test_getDataActions_wildcardWithEmptyOperationsMap(t *testing.T) {
-	getStoredOperationsMap = func() azureutils.OperationsMap {
-		return azureutils.NewOperationsMap()
-	}
+	setStoredOperationsMap(t, azureutils.NewOperationsMap())
 
 	tests := []struct {
 		name string
@@ -897,7 +903,7 @@ func Test_prepareCheckAccessRequestBodyWithCustomResource(t *testing.T) {
 		},
 	}
 	clusterType := aksClusterType
-	createOperationsMap(clusterType)
+	setStoredOperationsMap(t, createOperationsMap(clusterType))
 
 	ctx := context.Background()
 	got, _ := prepareCheckAccessRequestBody(ctx, req, clusterType, resourceId, false, true, false)
@@ -937,9 +943,7 @@ func Test_prepareCheckAccessRequestBodyWithCustomResourceOperationsMapEmpty(t *t
 	}
 	clusterType := aksClusterType
 
-	getStoredOperationsMap = func() azureutils.OperationsMap {
-		return azureutils.OperationsMap{}
-	}
+	setStoredOperationsMap(t, azureutils.OperationsMap{})
 
 	ctx := context.Background()
 	got, _ := prepareCheckAccessRequestBody(ctx, req, clusterType, resourceId, false, true, false)
@@ -971,10 +975,7 @@ func Test_prepareCheckAccessRequestBodyWithCustomResourceTypeCheckDisabled(t *te
 	}
 	clusterType := aksClusterType
 	operationsMap := createOperationsMap(clusterType)
-
-	getStoredOperationsMap = func() azureutils.OperationsMap {
-		return operationsMap
-	}
+	setStoredOperationsMap(t, operationsMap)
 
 	ctx := context.Background()
 	got, _ := prepareCheckAccessRequestBody(ctx, req, clusterType, resourceId, false, false, false)
@@ -1006,10 +1007,7 @@ func Test_prepareCheckAccessRequestBodyWithCustomResourceAndStars(t *testing.T) 
 	}
 	clusterType := aksClusterType
 	operationsMap := createOperationsMap(clusterType)
-
-	getStoredOperationsMap = func() azureutils.OperationsMap {
-		return operationsMap
-	}
+	setStoredOperationsMap(t, operationsMap)
 
 	ctx := context.Background()
 	got, _ := prepareCheckAccessRequestBody(ctx, req, clusterType, resourceId, false, true, false)

--- a/authz/providers/azure/rbac/checkaccessreqhelper_test.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper_test.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"reflect"
 	"strings"
 	"testing"
 
 	azureutils "go.kubeguard.dev/guard/util/azure"
+	errutils "go.kubeguard.dev/guard/util/error"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -686,6 +688,62 @@ func Test_getDataActions(t *testing.T) {
 					}
 				}
 			}
+		})
+	}
+}
+
+func Test_getDataActions_wildcardWithEmptyOperationsMap(t *testing.T) {
+	getStoredOperationsMap = func() azureutils.OperationsMap {
+		return azureutils.NewOperationsMap()
+	}
+
+	tests := []struct {
+		name string
+		spec *authzv1.SubjectAccessReviewSpec
+	}{
+		{
+			name: "wildcard resource",
+			spec: &authzv1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Verb:      "create",
+					Namespace: "kube-system",
+					Resource:  "*",
+				},
+			},
+		},
+		{
+			name: "wildcard verb",
+			spec: &authzv1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Verb:     "*",
+					Resource: "pods",
+				},
+			},
+		},
+		{
+			name: "wildcard group",
+			spec: &authzv1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Verb:     "get",
+					Resource: "pods",
+					Group:    "*",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			got, err := getDataActions(ctx, tt.spec, "Microsoft.ContainerService/managedClusters", false, false)
+
+			assert.Nil(t, got, "expected nil actions for wildcard with empty operations map")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "operations map not populated")
+
+			var codeErr errutils.HttpStatusCode
+			assert.True(t, errors.As(err, &codeErr), "error should implement HttpStatusCode")
+			assert.Equal(t, http.StatusBadRequest, codeErr.Code(), "error should carry 400 status code")
 		})
 	}
 }

--- a/authz/providers/azure/rbac/checkaccessreqhelper_test.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper_test.go
@@ -1487,3 +1487,57 @@ func Test_buildCheckAccessURL(t *testing.T) {
 		})
 	}
 }
+
+func Test_buildCheckAccessV2URL(t *testing.T) {
+	tests := []struct {
+		name       string
+		endpoint   string
+		apiVersion string
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:     "bare regional host gets checkaccess path and default api-version",
+			endpoint: "https://westcentralus.authorization.azure.net",
+			want:     "https://westcentralus.authorization.azure.net/providers/Microsoft.Authorization/checkaccess?api-version=" + defaultCheckAccessV2APIVersion,
+		},
+		{
+			name:     "trailing slash does not produce a double slash",
+			endpoint: "https://westcentralus.authorization.azure.net/",
+			want:     "https://westcentralus.authorization.azure.net/providers/Microsoft.Authorization/checkaccess?api-version=" + defaultCheckAccessV2APIVersion,
+		},
+		{
+			name:       "explicit api-version overrides the default",
+			endpoint:   "https://eastus2.authorization.azure.net",
+			apiVersion: "2099-01-01",
+			want:       "https://eastus2.authorization.azure.net/providers/Microsoft.Authorization/checkaccess?api-version=2099-01-01",
+		},
+		{
+			name:     "fully formed url with checkaccess path is returned unchanged",
+			endpoint: "https://eastus2.authorization.azure.net/providers/microsoft.authorization/checkAccess?api-version=2021-06-01-preview",
+			want:     "https://eastus2.authorization.azure.net/providers/microsoft.authorization/checkAccess?api-version=2021-06-01-preview",
+		},
+		{
+			name:     "empty endpoint returns error",
+			endpoint: "",
+			wantErr:  true,
+		},
+		{
+			name:     "non-https endpoint returns error",
+			endpoint: "http://westcentralus.authorization.azure.net",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildCheckAccessV2URL(tt.endpoint, tt.apiVersion)
+			if tt.wantErr {
+				assert.Errorf(t, err, "expect error, but got none. Got: %q", got)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -50,15 +50,19 @@ import (
 )
 
 const (
-	managedClusters           = "Microsoft.ContainerService/managedClusters"
-	fleets                    = "Microsoft.ContainerService/fleets"
-	fleetMembers              = "Microsoft.ContainerService/fleets/members"
-	aiManagers                = "Microsoft.ContainerService/aiManagers"
-	connectedClusters         = "Microsoft.Kubernetes/connectedClusters"
-	checkAccessPath           = "/providers/Microsoft.Authorization/checkaccess"
-	queryParamAPIVersion      = "api-version"
-	checkAccessAPIVersion     = "2018-09-01-preview"
-	remainingSubReadARMHeader = "x-ms-ratelimit-remaining-subscription-reads"
+	managedClusters       = "Microsoft.ContainerService/managedClusters"
+	fleets                = "Microsoft.ContainerService/fleets"
+	fleetMembers          = "Microsoft.ContainerService/fleets/members"
+	aiManagers            = "Microsoft.ContainerService/aiManagers"
+	connectedClusters     = "Microsoft.Kubernetes/connectedClusters"
+	checkAccessPath       = "/providers/Microsoft.Authorization/checkaccess"
+	queryParamAPIVersion  = "api-version"
+	checkAccessAPIVersion = "2018-09-01-preview"
+	// defaultCheckAccessV2APIVersion is the PDP data-plane api-version used for
+	// CheckAccess v2 when --azure.checkaccess-v2-api-version is unset. Validated
+	// against the regional PDP endpoint (https://<region>.authorization.azure.net).
+	defaultCheckAccessV2APIVersion = "2021-06-01-preview"
+	remainingSubReadARMHeader      = "x-ms-ratelimit-remaining-subscription-reads"
 	// Time delta to refresh token before expiry
 	tokenExpiryDelta           = 300 * time.Second
 	checkaccessContextTimeout  = 23 * time.Second
@@ -92,9 +96,8 @@ type AccessInfo struct {
 
 	// V2 API fields - used only when useCheckAccessV2=true
 	// These fields use the official Azure checkaccess-v2-go-sdk
-	useCheckAccessV2     bool
-	pdpClient            checkaccess.RemotePDPClient
-	checkAccessV2Version string
+	useCheckAccessV2 bool
+	pdpClient        checkaccess.RemotePDPClient
 
 	tokenProvider                          graph.TokenProvider
 	clusterType                            string
@@ -203,7 +206,6 @@ func newAccessInfo(tokenProvider graph.TokenProvider, rbacURL *url.URL, opts aut
 		auditSAR:                               opts.AuditSAR,
 		fleetManagerResourceId:                 opts.FleetManagerResourceId,
 		useCheckAccessV2:                       opts.UseCheckAccessV2,
-		checkAccessV2Version:                   opts.CheckAccessV2APIVersion,
 	}
 
 	u.skipCheck = make(map[string]void, len(opts.SkipAuthzCheck))
@@ -232,8 +234,17 @@ func newAccessInfo(tokenProvider graph.TokenProvider, rbacURL *url.URL, opts aut
 			Transport: httpclient.DefaultHTTPClient,
 		}
 
+		// The checkaccess-v2-go-sdk POSTs directly to the endpoint with no path
+		// manipulation, so compose the full checkAccess URL (path + api-version)
+		// here. A bare regional PDP host returns a non-JSON 404 that the SDK then
+		// fails to decode ("invalid character ..."), so this step is required.
+		pdpEndpoint, err := buildCheckAccessV2URL(opts.PDPEndpoint, opts.CheckAccessV2APIVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build CheckAccess v2 PDP endpoint: %w", err)
+		}
+
 		pdpClient, err := checkaccess.NewRemotePDPClient(
-			opts.PDPEndpoint,
+			pdpEndpoint,
 			opts.PDPScope,
 			tokenCred,
 			clientOpts,


### PR DESCRIPTION
## Summary

- Guard builds the Azure RBAC DataAction strings in `getResourceAndAction` and `getDataActions`. Guard does not own that action namespace.
- An action string works only if the resource provider already publishes the same operation. If the operation does not exist, Azure denies the request and the customer cannot grant the permission.
- This failure mode is easy to miss. Unit tests pass, and standard AKS clusters do not show the problem.
- This change adds the rule, the verification command, and the current list of registered and unregistered actions to `CLAUDE.md`.

Documentation only. No code changes.

## Changes

`CLAUDE.md`:

- Two new items in **Known Gotchas**: the DataAction namespace rule, and the `system:` user bypass in `authz/providers/azure/azure.go`.
- A new section, **Changing the DataAction Mapping**, that gives:
  - The `az provider operation show` command to verify each new action.
  - What happens when the operation is absent: ARM refuses the action in a custom role with `InvalidDataActionOrNotDataAction`. The built-in Reader and Writer roles list leaf actions, so they do not match either. Only a role with a wildcard matches.
  - The registered and unregistered action inventory, measured on 2026-08-13.
  - Two review traps: a unit test asserts the string but not the grantability, and `system:` identities hide the change on standard clusters.

## How the facts were verified

Each statement was measured, not assumed:

| Statement | Method |
|---|---|
| `pods/exec/action` is registered | `az provider operation show --namespace Microsoft.ContainerService` |
| `certificatesigningrequests/nodeclient/action` is absent | same command |
| `pods/{attach,portforward,proxy}/action` are absent | same command |
| `services/proxy/action` and `nodes/proxy/action` are absent | same command |
| ARM refuses an unregistered DataAction | `az role definition create` returned `InvalidDataActionOrNotDataAction` |
| Reader and Writer list leaf actions | `az role definition list` for both roles |

## Architecture Diagrams

How Guard resolves a DataAction today, and where an unregistered action fails:

```mermaid
flowchart TD
    A[SubjectAccessReview] --> B{User starts with 'system:'?}
    B -->|Yes| C[NoOpinion. Azure RBAC is skipped.<br/>Standard AKS nodes stop here.]
    B -->|No| D[getResourceAndAction]
    D --> E[DataAction string]
    E --> F{Operation published by the RP?}
    F -->|Yes| G[Role can grant it.<br/>Allow or deny by assignment.]
    F -->|No| H[Wildcard roles match only.<br/>Admin and Cluster Admin.]
    H --> I[Denied for every<br/>least-privilege role]
    I --> J[Customer cannot fix it.<br/>ARM refuses the action<br/>in a custom role.]

    style C fill:#fff4ce,stroke:#8a6d00,color:#000
    style H fill:#ffd6cc,stroke:#a33,color:#000
    style I fill:#ffd6cc,stroke:#a33,color:#000
    style J fill:#ffb3a7,stroke:#a33,color:#000
```

Review process before and after this change:

```mermaid
flowchart LR
    subgraph BEFORE["Before"]
        A1[Change the mapping] --> A2[Add a unit test<br/>for the string]
        A2 --> A3[Tests pass]
        A3 --> A4[Merge]
        A4 --> A5[Denials found<br/>in production]
    end

    subgraph AFTER["After"]
        B1[Change the mapping] --> B2[Add a unit test<br/>for the string]
        B2 --> B3[NEW: check the RP<br/>operations registry]
        B3 --> B4{Operation exists?}
        B4 -->|Yes| B5[Merge]
        B4 -->|No| B6[Hold. The RP manifest<br/>must ship first.]
    end

    style A5 fill:#ffd6cc,stroke:#a33,color:#000
    style B3 fill:#d4f5d4,stroke:#2a7,color:#000
    style B6 fill:#fff4ce,stroke:#8a6d00,color:#000
```

## Infrastructure Changes

None. No new environment variable, secret, or permission.

To run the verification command, an engineer needs an Azure CLI login. The command is read-only.

## Trade-offs

- **The inventory has a date and will age.** The registered and unregistered lists are correct on 2026-08-13. The `az` command next to them is the source of truth. The list helps a reader see the current shape. The command gives the current answer.
- **The rule does not run in CI.** A CI check would need an Azure login with the correct subscription, so this is a written rule in `CLAUDE.md`, not a gate. A future automated check could parse the mapping and compare it against the operations registry.
- **The `system:` note describes present behaviour, not a recommendation.** The bypass in `authz/providers/azure/azure.go` is recorded because it hides this class of change during testing. This PR does not propose to change it.
- **Documentation only.** This PR does not change any action mapping. It gives reviewers the check to apply to the next mapping change.
